### PR TITLE
Introduce canonical work IDs pilot across representative composers

### DIFF
--- a/data/works/README.md
+++ b/data/works/README.md
@@ -1,0 +1,98 @@
+# Canonical work data
+
+This directory contains lightweight work identity records. The purpose is to separate the identity of a musical work from the way that work is displayed, translated, catalogued, or described by a streaming service.
+
+The records are intentionally incremental. A composer page may exist before any work records are present, and a composer may have only the works that are currently needed by the collection.
+
+## Location
+
+Work records are grouped by composer:
+
+```text
+data/works/<composer_id>/<work_id>.yaml
+```
+
+For example:
+
+```text
+data/works/hector-berlioz/berlioz-op14.yaml
+```
+
+## Required fields
+
+```yaml
+id: berlioz-op14
+composer_id: hector-berlioz
+canonical_title: Symphonie fantastique
+```
+
+- `id` is the repository's stable internal work identifier.
+- `composer_id` identifies the composer independently of the page title.
+- `canonical_title` is the default display title when no localized title is available.
+
+## Recommended fields
+
+```yaml
+localized_titles:
+  fr: Symphonie fantastique
+  en: Fantastic Symphony
+  nl: Symphonie fantastique
+
+catalogue:
+  opus: Op. 14
+  holoman: H. 48
+
+aliases:
+  - Fantastic Symphony
+  - Épisode de la vie d'un artiste
+  - Episode in the Life of an Artist
+  - Op. 14
+
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+
+notes: >-
+  Optional local notes about identity, title variants, or modelling choices.
+```
+
+- `localized_titles` supports language-specific display without changing the internal ID.
+- `catalogue` stores catalogue references such as opus numbers, Holoman numbers, or other work catalogue identifiers.
+- `aliases` stores names and metadata strings that may appear in recordings, streaming metadata, imports, or notes.
+- `authorities` stores external identifiers when they have been verified.
+- `notes` is optional and should only contain local modelling notes.
+
+## Identifier conventions
+
+Use stable, language-independent IDs. Prefer catalogue-based IDs when available:
+
+```text
+berlioz-op14
+berlioz-h138
+```
+
+When no reliable catalogue number is available, use a short normalized title:
+
+```text
+berlioz-rob-roy
+```
+
+The ID should not be changed merely because the displayed title changes.
+
+## Matching rule for future validation
+
+A future validation script should be able to match incoming metadata against:
+
+1. `id`
+2. `canonical_title`
+3. values in `localized_titles`
+4. values in `catalogue`
+5. values in `aliases`
+
+Matching should be case-insensitive and should normalize punctuation, accents, and repeated whitespace.
+
+## External authority evaluation
+
+MusicBrainz work IDs are suitable as optional external authority identifiers, because they identify works separately from recordings and releases. They should not replace local IDs, since local IDs need to remain stable even if an external database changes its preferred title or merge history.
+
+For the pilot, `musicbrainz_work_id` is included as a nullable field. The field should be populated only after the exact work entity has been verified. This avoids importing uncertain identifiers while keeping the format ready for authority-backed reconciliation.

--- a/data/works/bela-bartok/works.yaml
+++ b/data/works/bela-bartok/works.yaml
@@ -1,0 +1,197 @@
+composer_id: bela-bartok
+source_note: >-
+  Data-first representative pilot for a composer not yet represented by a markdown page.
+  It tests Sz catalogue identifiers, BB identifiers, translated titles, folk-based titles,
+  and works with common English/Hungarian variants.
+works:
+  - id: bartok-sz36-bb55
+    composer_id: bela-bartok
+    canonical_title: Bluebeard's Castle
+    localized_titles:
+      en: Bluebeard's Castle
+      hu: A kékszakállú herceg vára
+      nl: Blauwbaards burcht
+    category: opera
+    catalogue: { sz: Sz. 48, bb: BB 62 }
+    aliases: [Bluebeard's Castle, Duke Bluebeard's Castle, A kékszakállú herceg vára, Blauwbaards burcht, Sz. 48, BB 62]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-wooden-prince
+    composer_id: bela-bartok
+    canonical_title: The Wooden Prince
+    localized_titles:
+      en: The Wooden Prince
+      hu: A fából faragott királyfi
+      nl: De houten prins
+    category: ballet
+    catalogue: { sz: Sz. 60, bb: BB 74 }
+    aliases: [The Wooden Prince, A fából faragott királyfi, De houten prins, Sz. 60, BB 74]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-miraculous-mandarin
+    composer_id: bela-bartok
+    canonical_title: The Miraculous Mandarin
+    localized_titles:
+      en: The Miraculous Mandarin
+      hu: A csodálatos mandarin
+      nl: De wonderbaarlijke mandarijn
+    category: ballet
+    catalogue: { sz: Sz. 73, bb: BB 82 }
+    aliases: [The Miraculous Mandarin, A csodálatos mandarin, De wonderbaarlijke mandarijn, Suite from The Miraculous Mandarin, Sz. 73, BB 82]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-kossuth
+    composer_id: bela-bartok
+    canonical_title: Kossuth
+    localized_titles: { en: Kossuth, hu: Kossuth, nl: Kossuth }
+    category: orchestral
+    catalogue: { sz: Sz. 21, bb: BB 31 }
+    aliases: [Kossuth, symphonic poem, Sz. 21, BB 31]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-two-portraits
+    composer_id: bela-bartok
+    canonical_title: Two Portraits
+    localized_titles:
+      en: Two Portraits
+      hu: Két portré
+      nl: Twee portretten
+    category: orchestral
+    catalogue: { opus: Op. 5, sz: Sz. 37, bb: BB 48b }
+    aliases: [Two Portraits, Két portré, Twee portretten, Op. 5, Sz. 37, BB 48b]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-four-orchestral-pieces
+    composer_id: bela-bartok
+    canonical_title: Four Orchestral Pieces
+    localized_titles:
+      en: Four Orchestral Pieces
+      hu: Négy zenekari darab
+      nl: Vier orkeststukken
+    category: orchestral
+    catalogue: { opus: Op. 12, sz: Sz. 51, bb: BB 64 }
+    aliases: [Four Orchestral Pieces, Négy zenekari darab, Vier orkeststukken, Op. 12, Sz. 51, BB 64]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-dance-suite
+    composer_id: bela-bartok
+    canonical_title: Dance Suite
+    localized_titles:
+      en: Dance Suite
+      hu: Táncszvit
+      nl: Danssuite
+    category: orchestral
+    catalogue: { sz: Sz. 77, bb: BB 86a }
+    aliases: [Dance Suite, Táncszvit, Danssuite, Sz. 77, BB 86a]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-music-for-strings-percussion-celesta
+    composer_id: bela-bartok
+    canonical_title: Music for Strings, Percussion and Celesta
+    localized_titles:
+      en: Music for Strings, Percussion and Celesta
+      hu: Zene húros hangszerekre, ütőkre és cselesztára
+      nl: Muziek voor snaarinstrumenten, slagwerk en celesta
+    category: orchestral
+    catalogue: { sz: Sz. 106, bb: BB 114 }
+    aliases: [Music for Strings, Percussion and Celesta, Music for Strings Percussion and Celesta, Sz. 106, BB 114]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-concerto-for-orchestra
+    composer_id: bela-bartok
+    canonical_title: Concerto for Orchestra
+    localized_titles:
+      en: Concerto for Orchestra
+      hu: Concerto zenekarra
+      nl: Concert voor orkest
+    category: orchestral
+    catalogue: { sz: Sz. 116, bb: BB 123 }
+    aliases: [Concerto for Orchestra, Concerto zenekarra, Concert voor orkest, Sz. 116, BB 123]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-piano-concerto-1
+    composer_id: bela-bartok
+    canonical_title: Piano Concerto No. 1
+    localized_titles: { en: Piano Concerto No. 1, hu: Zongoraverseny No. 1, nl: Pianoconcert nr. 1 }
+    category: concertante
+    catalogue: { sz: Sz. 83, bb: BB 91 }
+    aliases: [Piano Concerto No. 1, First Piano Concerto, Sz. 83, BB 91]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-piano-concerto-2
+    composer_id: bela-bartok
+    canonical_title: Piano Concerto No. 2
+    localized_titles: { en: Piano Concerto No. 2, hu: Zongoraverseny No. 2, nl: Pianoconcert nr. 2 }
+    category: concertante
+    catalogue: { sz: Sz. 95, bb: BB 101 }
+    aliases: [Piano Concerto No. 2, Second Piano Concerto, Sz. 95, BB 101]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-piano-concerto-3
+    composer_id: bela-bartok
+    canonical_title: Piano Concerto No. 3
+    localized_titles: { en: Piano Concerto No. 3, hu: Zongoraverseny No. 3, nl: Pianoconcert nr. 3 }
+    category: concertante
+    catalogue: { sz: Sz. 119, bb: BB 127 }
+    aliases: [Piano Concerto No. 3, Third Piano Concerto, Sz. 119, BB 127]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-violin-concerto-1
+    composer_id: bela-bartok
+    canonical_title: Violin Concerto No. 1
+    localized_titles: { en: Violin Concerto No. 1, hu: Hegedűverseny No. 1, nl: Vioolconcert nr. 1 }
+    category: concertante
+    catalogue: { sz: Sz. 36, bb: BB 48a }
+    aliases: [Violin Concerto No. 1, First Violin Concerto, Sz. 36, BB 48a]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-violin-concerto-2
+    composer_id: bela-bartok
+    canonical_title: Violin Concerto No. 2
+    localized_titles: { en: Violin Concerto No. 2, hu: Hegedűverseny No. 2, nl: Vioolconcert nr. 2 }
+    category: concertante
+    catalogue: { sz: Sz. 112, bb: BB 117 }
+    aliases: [Violin Concerto No. 2, Second Violin Concerto, Sz. 112, BB 117]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-viola-concerto
+    composer_id: bela-bartok
+    canonical_title: Viola Concerto
+    localized_titles: { en: Viola Concerto, hu: Brácsaverseny, nl: Altvioolconcert }
+    category: concertante
+    catalogue: { sz: Sz. 120, bb: BB 128 }
+    aliases: [Viola Concerto, Brácsaverseny, Altvioolconcert, Sz. 120, BB 128]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-string-quartets
+    composer_id: bela-bartok
+    canonical_title: Six String Quartets
+    localized_titles: { en: Six String Quartets, hu: Hat vonósnégyes, nl: Zes strijkkwartetten }
+    category: chamber
+    aliases: [String Quartets, Six String Quartets, Bartók String Quartets, String Quartets Nos. 1-6]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-string-quartet-4
+    composer_id: bela-bartok
+    canonical_title: String Quartet No. 4
+    localized_titles: { en: String Quartet No. 4, hu: Vonósnégyes No. 4, nl: Strijkkwartet nr. 4 }
+    category: chamber
+    catalogue: { sz: Sz. 91, bb: BB 95 }
+    aliases: [String Quartet No. 4, Fourth String Quartet, Sz. 91, BB 95]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-sonata-for-two-pianos-and-percussion
+    composer_id: bela-bartok
+    canonical_title: Sonata for Two Pianos and Percussion
+    localized_titles: { en: Sonata for Two Pianos and Percussion, nl: Sonate voor twee piano's en slagwerk }
+    category: chamber
+    catalogue: { sz: Sz. 110, bb: BB 115 }
+    aliases: [Sonata for Two Pianos and Percussion, Sonata for 2 Pianos and Percussion, Sz. 110, BB 115]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-mikrokosmos
+    composer_id: bela-bartok
+    canonical_title: Mikrokosmos
+    localized_titles: { en: Mikrokosmos, hu: Mikrokozmosz, nl: Mikrokosmos }
+    category: piano
+    catalogue: { sz: Sz. 107, bb: BB 105 }
+    aliases: [Mikrokosmos, Mikrokozmosz, Mikrokosmosz, Sz. 107, BB 105]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-romanian-folk-dances
+    composer_id: bela-bartok
+    canonical_title: Romanian Folk Dances
+    localized_titles: { en: Romanian Folk Dances, hu: Román népi táncok, nl: Roemeense volksdansen }
+    category: piano-or-orchestral
+    catalogue: { sz: Sz. 56, bb: BB 68 }
+    aliases: [Romanian Folk Dances, Romanian Folk Dances from Hungary, Román népi táncok, Sz. 56, BB 68]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bartok-allegro-barbaro
+    composer_id: bela-bartok
+    canonical_title: Allegro barbaro
+    localized_titles: { en: Allegro barbaro, hu: Allegro barbaro, nl: Allegro barbaro }
+    category: piano
+    catalogue: { sz: Sz. 49, bb: BB 63 }
+    aliases: [Allegro barbaro, Sz. 49, BB 63]
+    authorities: { musicbrainz_work_id:, wikidata: }

--- a/data/works/carl-philipp-emanuel-bach/works.yaml
+++ b/data/works/carl-philipp-emanuel-bach/works.yaml
@@ -1,0 +1,128 @@
+composer_id: carl-philipp-emanuel-bach
+source_note: >-
+  Data-first representative pilot for a composer not yet represented by a markdown page.
+  This tests Wq/H catalogue identifiers, title translations, and work groups.
+works:
+  - id: cpebach-wq20-h186
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Magnificat in D major
+    localized_titles:
+      en: Magnificat in D major
+      de: Magnificat D-Dur
+      nl: Magnificat in D groot
+    category: sacred-vocal
+    catalogue: { wq: Wq 215, h: H 772 }
+    aliases: [Magnificat, Magnificat in D major, Wq 215, H 772]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq183
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Four Orchestral Symphonies
+    localized_titles:
+      en: Four Orchestral Symphonies
+      de: Vier Orchestersinfonien
+      nl: Vier orkestsymfonieën
+    category: orchestral
+    catalogue: { wq: Wq 183 }
+    aliases: [Four Orchestral Symphonies, Hamburg Symphonies, Symphonies Wq 183, Wq 183]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq182
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Six String Symphonies
+    localized_titles:
+      en: Six String Symphonies
+      de: Sechs Streichersinfonien
+      nl: Zes strijkerssymfonieën
+    category: orchestral
+    catalogue: { wq: Wq 182 }
+    aliases: [Six String Symphonies, Hamburg String Symphonies, Symphonies Wq 182, Wq 182]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq22
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Keyboard Concerto in D minor
+    localized_titles:
+      en: Keyboard Concerto in D minor
+      de: Klavierkonzert d-Moll
+      nl: Klavierconcert in d klein
+    category: concertante
+    catalogue: { wq: Wq 22 }
+    aliases: [Keyboard Concerto in D minor, Harpsichord Concerto in D minor, Wq 22]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq23
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Keyboard Concerto in G major
+    localized_titles:
+      en: Keyboard Concerto in G major
+      de: Klavierkonzert G-Dur
+      nl: Klavierconcert in G groot
+    category: concertante
+    catalogue: { wq: Wq 23 }
+    aliases: [Keyboard Concerto in G major, Harpsichord Concerto in G major, Wq 23]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq35
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Flute Concerto in D minor
+    localized_titles:
+      en: Flute Concerto in D minor
+      de: Flötenkonzert d-Moll
+      nl: Fluitconcert in d klein
+    category: concertante
+    catalogue: { wq: Wq 22 }
+    aliases: [Flute Concerto in D minor, Flötenkonzert d-Moll, Wq 22]
+    authorities: { musicbrainz_work_id:, wikidata: }
+    notes: >-
+      Included to test cases where related concerto versions share source material and catalogue references.
+  - id: cpebach-wq170
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Oboe Concerto in B-flat major
+    localized_titles:
+      en: Oboe Concerto in B-flat major
+      de: Oboenkonzert B-Dur
+      nl: Hoboconcert in Bes groot
+    category: concertante
+    catalogue: { wq: Wq 164 }
+    aliases: [Oboe Concerto in B-flat major, Oboenkonzert B-Dur, Wq 164]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq49
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Prussian Sonatas
+    localized_titles:
+      en: Prussian Sonatas
+      de: Preußische Sonaten
+      nl: Pruisische sonates
+    category: keyboard
+    catalogue: { wq: Wq 48 }
+    aliases: [Prussian Sonatas, Preußische Sonaten, Six Prussian Sonatas, Wq 48]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq49-wuerttemberg
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Württemberg Sonatas
+    localized_titles:
+      en: Württemberg Sonatas
+      de: Württembergische Sonaten
+      nl: Württembergse sonates
+    category: keyboard
+    catalogue: { wq: Wq 49 }
+    aliases: [Württemberg Sonatas, Württembergische Sonaten, Six Württemberg Sonatas, Wq 49]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq55-clavier-fuer-kenner-und-liebhaber
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Für Kenner und Liebhaber
+    localized_titles:
+      en: For Connoisseurs and Amateurs
+      de: Für Kenner und Liebhaber
+      nl: Voor kenners en liefhebbers
+    category: keyboard
+    catalogue: { wq: Wq 55-59, 61 }
+    aliases: [Für Kenner und Liebhaber, For Connoisseurs and Amateurs, Clavier-Sonaten und freie Fantasien, Wq 55-59, Wq 61]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: cpebach-wq67
+    composer_id: carl-philipp-emanuel-bach
+    canonical_title: Solfeggietto in C minor
+    localized_titles:
+      en: Solfeggietto in C minor
+      de: Solfeggietto c-Moll
+      nl: Solfeggietto in c klein
+    category: keyboard
+    catalogue: { wq: Wq 117/2, h: H 220 }
+    aliases: [Solfeggietto, Solfeggio in C minor, Solfeggietto in C minor, Wq 117/2, H 220]
+    authorities: { musicbrainz_work_id:, wikidata: }

--- a/data/works/hector-berlioz/berlioz-h138.yaml
+++ b/data/works/hector-berlioz/berlioz-h138.yaml
@@ -1,0 +1,22 @@
+id: berlioz-h138
+composer_id: hector-berlioz
+canonical_title: Béatrice et Bénédict
+localized_titles:
+  fr: Béatrice et Bénédict
+  en: Beatrice and Benedict
+  nl: Béatrice et Bénédict
+catalogue:
+  holoman: H. 138
+aliases:
+  - Béatrice et Bénédict, H. 138
+  - Beatrice et Benedict
+  - Beatrice and Benedict
+  - Beatrice and Benedict Overture
+  - Ouverture Béatrice et Bénédict
+  - H. 138
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  The current collection page links the overture. This record identifies the work title
+  used there; an overture-specific child work can be added later if needed.

--- a/data/works/hector-berlioz/berlioz-marche-troyenne.yaml
+++ b/data/works/hector-berlioz/berlioz-marche-troyenne.yaml
@@ -1,0 +1,17 @@
+id: berlioz-marche-troyenne
+composer_id: hector-berlioz
+canonical_title: Marche Troyenne
+localized_titles:
+  fr: Marche Troyenne
+  en: Trojan March
+  nl: Trojaanse mars
+catalogue: {}
+aliases:
+  - Marche troyenne
+  - Trojan March
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  No catalogue number is shown on the current Berlioz collection page, so the ID uses
+  a normalized title rather than a catalogue-based identifier.

--- a/data/works/hector-berlioz/berlioz-op1.yaml
+++ b/data/works/hector-berlioz/berlioz-op1.yaml
@@ -1,0 +1,19 @@
+id: berlioz-op1
+composer_id: hector-berlioz
+canonical_title: Waverley
+localized_titles:
+  fr: Waverley
+  en: Waverley
+  nl: Waverley
+catalogue:
+  opus: Op. 1
+aliases:
+  - Waverley, Op. 1
+  - Waverley Overture
+  - Ouverture Waverley
+  - Op. 1
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled from the current Berlioz collection page as an orchestral overture.

--- a/data/works/hector-berlioz/berlioz-op14.yaml
+++ b/data/works/hector-berlioz/berlioz-op14.yaml
@@ -1,0 +1,22 @@
+id: berlioz-op14
+composer_id: hector-berlioz
+canonical_title: Symphonie fantastique
+localized_titles:
+  fr: Symphonie fantastique
+  en: Fantastic Symphony
+  nl: Symphonie fantastique
+catalogue:
+  opus: Op. 14
+aliases:
+  - Symphonie fantastique, Op. 14
+  - Fantastic Symphony
+  - Épisode de la vie d'un artiste
+  - Episode in the Life of an Artist
+  - Episode de la vie d'un artiste
+  - Op. 14
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  This is the motivating example from issue 59 and demonstrates translated titles,
+  programme subtitles, and catalogue aliases referring to the same work identity.

--- a/data/works/hector-berlioz/berlioz-op15.yaml
+++ b/data/works/hector-berlioz/berlioz-op15.yaml
@@ -1,0 +1,20 @@
+id: berlioz-op15
+composer_id: hector-berlioz
+canonical_title: Grande symphonie funèbre et triomphale
+localized_titles:
+  fr: Grande symphonie funèbre et triomphale
+  en: Grande symphonie funèbre et triomphale
+  nl: Grande symphonie funèbre et triomphale
+catalogue:
+  opus: Op. 15
+aliases:
+  - Grande symphonie funèbre et triomphale, Op. 15
+  - Grande Symphonie funèbre et triomphale
+  - Funeral and Triumphal Symphony
+  - Grand Funeral and Triumphal Symphony
+  - Op. 15
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  English descriptive aliases are included for likely streaming metadata variants.

--- a/data/works/hector-berlioz/berlioz-op16.yaml
+++ b/data/works/hector-berlioz/berlioz-op16.yaml
@@ -1,0 +1,21 @@
+id: berlioz-op16
+composer_id: hector-berlioz
+canonical_title: Harold en Italie
+localized_titles:
+  fr: Harold en Italie
+  en: Harold in Italy
+  nl: Harold in Italië
+catalogue:
+  opus: Op. 16
+aliases:
+  - Harold en Italie, Op. 16
+  - Harold in Italy
+  - Harold in Italy, Op. 16
+  - Symphony with Viola Obbligato
+  - Symphonie avec alto principal
+  - Op. 16
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled as the complete symphonic work with viola obbligato.

--- a/data/works/hector-berlioz/berlioz-op17.yaml
+++ b/data/works/hector-berlioz/berlioz-op17.yaml
@@ -1,0 +1,22 @@
+id: berlioz-op17
+composer_id: hector-berlioz
+canonical_title: Roméo et Juliette
+localized_titles:
+  fr: Roméo et Juliette
+  en: Romeo and Juliet
+  nl: Romeo en Julia
+catalogue:
+  opus: Op. 17
+aliases:
+  - Roméo et Juliette, Op. 17
+  - Romeo et Juliette
+  - Romeo and Juliet
+  - Romeo and Juliet, Op. 17
+  - Dramatic Symphony
+  - Symphonie dramatique
+  - Op. 17
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled as the complete dramatic symphony rather than individual movements.

--- a/data/works/hector-berlioz/berlioz-op18-h119.yaml
+++ b/data/works/hector-berlioz/berlioz-op18-h119.yaml
@@ -1,0 +1,20 @@
+id: berlioz-op18-h119
+composer_id: hector-berlioz
+canonical_title: Tristia
+localized_titles:
+  fr: Tristia
+  en: Tristia
+  nl: Tristia
+catalogue:
+  opus: Op. 18
+  holoman: H. 119
+aliases:
+  - Tristia, Op. 18
+  - Tristia, H. 119
+  - Op. 18
+  - H. 119
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled as the grouped work identity used by the current Berlioz collection page.

--- a/data/works/hector-berlioz/berlioz-op21.yaml
+++ b/data/works/hector-berlioz/berlioz-op21.yaml
@@ -1,0 +1,20 @@
+id: berlioz-op21
+composer_id: hector-berlioz
+canonical_title: Le Corsaire
+localized_titles:
+  fr: Le Corsaire
+  en: The Corsair
+  nl: De kaper
+catalogue:
+  opus: Op. 21
+aliases:
+  - Le Corsaire, Op. 21
+  - The Corsair
+  - Corsair Overture
+  - Ouverture Le Corsaire
+  - Op. 21
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled from the overture entry on the current Berlioz collection page.

--- a/data/works/hector-berlioz/berlioz-op23.yaml
+++ b/data/works/hector-berlioz/berlioz-op23.yaml
@@ -1,0 +1,20 @@
+id: berlioz-op23
+composer_id: hector-berlioz
+canonical_title: Benvenuto Cellini
+localized_titles:
+  fr: Benvenuto Cellini
+  en: Benvenuto Cellini
+  nl: Benvenuto Cellini
+catalogue:
+  opus: Op. 23
+aliases:
+  - Benvenuto Cellini, Op. 23
+  - Benvenuto Cellini Overture
+  - Ouverture Benvenuto Cellini
+  - Op. 23
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  The current collection page links the overture. This record identifies the work title
+  used there; an overture-specific child work can be added later if needed.

--- a/data/works/hector-berlioz/berlioz-op3.yaml
+++ b/data/works/hector-berlioz/berlioz-op3.yaml
@@ -1,0 +1,20 @@
+id: berlioz-op3
+composer_id: hector-berlioz
+canonical_title: Grande Ouverture des franc-juges
+localized_titles:
+  fr: Grande Ouverture des franc-juges
+  en: Overture to Les francs-juges
+  nl: Ouverture Les francs-juges
+catalogue:
+  opus: Op. 3
+aliases:
+  - Les francs-juges
+  - Grande Ouverture des Francs-Juges
+  - Grande ouverture des franc-juges, Op. 3
+  - Overture to Les francs-juges
+  - Op. 3
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled as the overture entry currently used in the Berlioz collection page.

--- a/data/works/hector-berlioz/berlioz-op4.yaml
+++ b/data/works/hector-berlioz/berlioz-op4.yaml
@@ -1,0 +1,19 @@
+id: berlioz-op4
+composer_id: hector-berlioz
+canonical_title: Le roi Lear
+localized_titles:
+  fr: Le roi Lear
+  en: King Lear
+  nl: Koning Lear
+catalogue:
+  opus: Op. 4
+aliases:
+  - Le roi Lear, Op. 4
+  - King Lear Overture
+  - Ouverture Le roi Lear
+  - Op. 4
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled from the current Berlioz collection page as an overture.

--- a/data/works/hector-berlioz/berlioz-op5-h75.yaml
+++ b/data/works/hector-berlioz/berlioz-op5-h75.yaml
@@ -1,0 +1,23 @@
+id: berlioz-op5-h75
+composer_id: hector-berlioz
+canonical_title: Grande messe des morts
+localized_titles:
+  fr: Grande messe des morts
+  en: Requiem
+  nl: Requiem
+catalogue:
+  opus: Op. 5
+  holoman: H. 75
+aliases:
+  - Grande Messe des morts
+  - Grande messe des morts, Op. 5
+  - Grande messe des morts, H. 75
+  - Requiem
+  - Requiem, Op. 5
+  - Op. 5
+  - H. 75
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  The common English title Requiem is included as an alias and localized title.

--- a/data/works/hector-berlioz/berlioz-op7.yaml
+++ b/data/works/hector-berlioz/berlioz-op7.yaml
@@ -1,0 +1,20 @@
+id: berlioz-op7
+composer_id: hector-berlioz
+canonical_title: Les Nuits d'été
+localized_titles:
+  fr: Les Nuits d'été
+  en: Summer Nights
+  nl: Zomernachten
+catalogue:
+  opus: Op. 7
+aliases:
+  - Les Nuits d'été, Op. 7
+  - Nuits d'été
+  - Summer Nights
+  - Summer Nights, Op. 7
+  - Op. 7
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled as the song cycle identity; individual songs can be modelled later if needed.

--- a/data/works/hector-berlioz/berlioz-op8.yaml
+++ b/data/works/hector-berlioz/berlioz-op8.yaml
@@ -1,0 +1,21 @@
+id: berlioz-op8
+composer_id: hector-berlioz
+canonical_title: Rêverie et caprice
+localized_titles:
+  fr: Rêverie et caprice
+  en: Reverie and Caprice
+  nl: Rêverie et caprice
+catalogue:
+  opus: Op. 8
+aliases:
+  - Rêverie et caprice, Op. 8
+  - Reverie and Caprice
+  - Reverie et caprice
+  - Romance for Violin and Orchestra
+  - Romance pour violon et orchestre
+  - Op. 8
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Includes the descriptive subtitle used on the current Berlioz collection page.

--- a/data/works/hector-berlioz/berlioz-op9.yaml
+++ b/data/works/hector-berlioz/berlioz-op9.yaml
@@ -1,0 +1,21 @@
+id: berlioz-op9
+composer_id: hector-berlioz
+canonical_title: Le Carnaval romain
+localized_titles:
+  fr: Le Carnaval romain
+  en: Roman Carnival Overture
+  nl: Romeins carnaval
+catalogue:
+  opus: Op. 9
+aliases:
+  - Le Carnaval romain, Op. 9
+  - Carnaval romain
+  - Roman Carnival
+  - Roman Carnival Overture
+  - Ouverture Le Carnaval romain
+  - Op. 9
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  Modelled from the overture entry on the current Berlioz collection page.

--- a/data/works/hector-berlioz/berlioz-rob-roy.yaml
+++ b/data/works/hector-berlioz/berlioz-rob-roy.yaml
@@ -1,0 +1,17 @@
+id: berlioz-rob-roy
+composer_id: hector-berlioz
+canonical_title: Rob Roy
+localized_titles:
+  fr: Rob Roy
+  en: Rob Roy
+  nl: Rob Roy
+catalogue: {}
+aliases:
+  - Rob Roy Overture
+  - Ouverture Rob Roy
+authorities:
+  musicbrainz_work_id:
+  wikidata:
+notes: >-
+  No catalogue number is shown on the current Berlioz collection page, so the ID uses
+  a normalized title rather than a catalogue-based identifier.

--- a/data/works/johann-sebastian-bach/works.yaml
+++ b/data/works/johann-sebastian-bach/works.yaml
@@ -1,0 +1,213 @@
+composer_id: johann-sebastian-bach
+source_note: >-
+  Representative pilot set based on the existing docs/bachJS.md page. The purpose is to
+  test BWV-based identities, ranges, arrangements, and major title aliases before a full
+  Bach migration.
+works:
+  - id: bach-bwv1041
+    composer_id: johann-sebastian-bach
+    canonical_title: Violin Concerto No. 1 in A minor
+    localized_titles:
+      en: Violin Concerto No. 1 in A minor
+      de: Violinkonzert Nr. 1 a-Moll
+      nl: Vioolconcert nr. 1 in a klein
+    category: orchestral
+    catalogue: { bwv: BWV 1041 }
+    aliases: [Concerto for violin and orchestra No. 1 in A minor, Violin Concerto in A minor, BWV 1041]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1042
+    composer_id: johann-sebastian-bach
+    canonical_title: Violin Concerto No. 2 in E major
+    localized_titles:
+      en: Violin Concerto No. 2 in E major
+      de: Violinkonzert Nr. 2 E-Dur
+      nl: Vioolconcert nr. 2 in E groot
+    category: orchestral
+    catalogue: { bwv: BWV 1042 }
+    aliases: [Concerto for violin and orchestra No. 2 in E major, Violin Concerto in E major, BWV 1042]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1043
+    composer_id: johann-sebastian-bach
+    canonical_title: Concerto for Two Violins in D minor
+    localized_titles:
+      en: Concerto for Two Violins in D minor
+      de: Konzert für zwei Violinen d-Moll
+      nl: Dubbelconcert voor twee violen in d klein
+    category: orchestral
+    catalogue: { bwv: BWV 1043 }
+    aliases: [Double Concerto, Concerto for 2 violins and orchestra, BWV 1043]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1044
+    composer_id: johann-sebastian-bach
+    canonical_title: Triple Concerto in A minor
+    localized_titles:
+      en: Triple Concerto in A minor
+      nl: Tripelconcert in a klein
+    category: orchestral
+    catalogue: { bwv: BWV 1044 }
+    aliases: [Concerto for flute, violin, harpsichord and orchestra, Triple Concerto, BWV 1044]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1046-2
+    composer_id: johann-sebastian-bach
+    canonical_title: Brandenburg Concerto No. 1 in F major
+    localized_titles:
+      en: Brandenburg Concerto No. 1 in F major
+      de: Brandenburgisches Konzert Nr. 1 F-Dur
+      nl: Brandenburgs concert nr. 1 in F groot
+    category: orchestral
+    catalogue: { bwv: BWV 1046.2 }
+    aliases: [Brandenburg Concerto No. 1, Brandenburgisches Konzert Nr. 1, BWV 1046, BWV 1046.2]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1047
+    composer_id: johann-sebastian-bach
+    canonical_title: Brandenburg Concerto No. 2 in F major
+    localized_titles:
+      en: Brandenburg Concerto No. 2 in F major
+      de: Brandenburgisches Konzert Nr. 2 F-Dur
+      nl: Brandenburgs concert nr. 2 in F groot
+    category: orchestral
+    catalogue: { bwv: BWV 1047 }
+    aliases: [Brandenburg Concerto No. 2, Brandenburgisches Konzert Nr. 2, BWV 1047]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1048
+    composer_id: johann-sebastian-bach
+    canonical_title: Brandenburg Concerto No. 3 in G major
+    localized_titles:
+      en: Brandenburg Concerto No. 3 in G major
+      de: Brandenburgisches Konzert Nr. 3 G-Dur
+      nl: Brandenburgs concert nr. 3 in G groot
+    category: orchestral
+    catalogue: { bwv: BWV 1048 }
+    aliases: [Brandenburg Concerto No. 3, Brandenburgisches Konzert Nr. 3, BWV 1048]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1049
+    composer_id: johann-sebastian-bach
+    canonical_title: Brandenburg Concerto No. 4 in G major
+    localized_titles:
+      en: Brandenburg Concerto No. 4 in G major
+      de: Brandenburgisches Konzert Nr. 4 G-Dur
+      nl: Brandenburgs concert nr. 4 in G groot
+    category: orchestral
+    catalogue: { bwv: BWV 1049 }
+    aliases: [Brandenburg Concerto No. 4, Brandenburgisches Konzert Nr. 4, BWV 1049]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1050-1
+    composer_id: johann-sebastian-bach
+    canonical_title: Brandenburg Concerto No. 5 in D major
+    localized_titles:
+      en: Brandenburg Concerto No. 5 in D major
+      de: Brandenburgisches Konzert Nr. 5 D-Dur
+      nl: Brandenburgs concert nr. 5 in D groot
+    category: orchestral
+    catalogue: { bwv: BWV 1050.1 }
+    aliases: [Brandenburg Concerto No. 5, revised version, BWV 1050, BWV 1050.1]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1051
+    composer_id: johann-sebastian-bach
+    canonical_title: Brandenburg Concerto No. 6 in B-flat major
+    localized_titles:
+      en: Brandenburg Concerto No. 6 in B-flat major
+      de: Brandenburgisches Konzert Nr. 6 B-Dur
+      nl: Brandenburgs concert nr. 6 in Bes groot
+    category: orchestral
+    catalogue: { bwv: BWV 1051 }
+    aliases: [Brandenburg Concerto No. 6, Brandenburgisches Konzert Nr. 6, BWV 1051]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1052-2
+    composer_id: johann-sebastian-bach
+    canonical_title: Harpsichord Concerto No. 1 in D minor
+    localized_titles:
+      en: Harpsichord Concerto No. 1 in D minor
+      nl: Klavecimbelconcert nr. 1 in d klein
+    category: orchestral
+    catalogue: { bwv: BWV 1052.2 }
+    aliases: [Concerto for harpsichord and orchestra No. 1, Harpsichord Concerto in D minor, BWV 1052, BWV 1052.2]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1066
+    composer_id: johann-sebastian-bach
+    canonical_title: Orchestral Suite No. 1 in C major
+    localized_titles:
+      en: Orchestral Suite No. 1 in C major
+      de: Orchestersuite Nr. 1 C-Dur
+      nl: Orkestsuite nr. 1 in C groot
+    category: orchestral
+    catalogue: { bwv: BWV 1066 }
+    aliases: [Ouverture No. 1, Orchestral Suite No. 1, BWV 1066]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1067
+    composer_id: johann-sebastian-bach
+    canonical_title: Orchestral Suite No. 2 in B minor
+    localized_titles:
+      en: Orchestral Suite No. 2 in B minor
+      de: Orchestersuite Nr. 2 h-Moll
+      nl: Orkestsuite nr. 2 in b klein
+    category: orchestral
+    catalogue: { bwv: BWV 1067 }
+    aliases: [Ouverture No. 2, Orchestral Suite No. 2, BWV 1067]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1068
+    composer_id: johann-sebastian-bach
+    canonical_title: Orchestral Suite No. 3 in D major
+    localized_titles:
+      en: Orchestral Suite No. 3 in D major
+      de: Orchestersuite Nr. 3 D-Dur
+      nl: Orkestsuite nr. 3 in D groot
+    category: orchestral
+    catalogue: { bwv: BWV 1068 }
+    aliases: [Ouverture No. 3, Orchestral Suite No. 3, Air on the G String, BWV 1068]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv1001-1006
+    composer_id: johann-sebastian-bach
+    canonical_title: Sonatas and Partitas for Solo Violin
+    localized_titles:
+      en: Sonatas and Partitas for Solo Violin
+      de: Sonaten und Partiten für Violine solo
+      nl: Sonates en partita's voor viool solo
+    category: chamber
+    catalogue: { bwv: BWV 1001-1006 }
+    aliases: [Six Sonatas and Partitas for Solo Violin, Sonatas and partitas for solo violin, BWV 1001-1006]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv988
+    composer_id: johann-sebastian-bach
+    canonical_title: Goldberg Variations
+    localized_titles:
+      en: Goldberg Variations
+      de: Goldberg-Variationen
+      nl: Goldbergvariaties
+    category: keyboard
+    catalogue: { bwv: BWV 988 }
+    aliases: [Goldberg Variations, Goldberg-Variationen, Goldbergvariaties, BWV 988]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv846-869
+    composer_id: johann-sebastian-bach
+    canonical_title: The Well-Tempered Clavier, Book I
+    localized_titles:
+      en: The Well-Tempered Clavier, Book I
+      de: Das wohltemperierte Klavier, Teil I
+      nl: Das Wohltemperierte Klavier, Boek I
+    category: keyboard
+    catalogue: { bwv: BWV 846-869 }
+    aliases: [Well-Tempered Clavier Book 1, WTC I, Das wohltemperierte Klavier I, BWV 846-869]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv870-893
+    composer_id: johann-sebastian-bach
+    canonical_title: The Well-Tempered Clavier, Book II
+    localized_titles:
+      en: The Well-Tempered Clavier, Book II
+      de: Das wohltemperierte Klavier, Teil II
+      nl: Das Wohltemperierte Klavier, Boek II
+    category: keyboard
+    catalogue: { bwv: BWV 870-893 }
+    aliases: [Well-Tempered Clavier Book 2, WTC II, Das wohltemperierte Klavier II, BWV 870-893]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: bach-bwv245
+    composer_id: johann-sebastian-bach
+    canonical_title: St John Passion
+    localized_titles:
+      en: St John Passion
+      de: Johannes-Passion
+      nl: Johannes-Passion
+    category: passions-oratorios
+    catalogue: { bwv: BWV 245 }
+    aliases: [Johannes-Passion, St John Passion, Saint John Passion, BWV 245]
+    authorities: { musicbrainz_work_id:, wikidata: }

--- a/data/works/john-adams/works.yaml
+++ b/data/works/john-adams/works.yaml
@@ -1,0 +1,1226 @@
+composer_id: john-adams
+works:
+  - id: adams-nixon-in-china
+    composer_id: john-adams
+    canonical_title: Nixon in China
+    localized_titles:
+      en: Nixon in China
+      nl: Nixon in China
+    year: 1987
+    category: operas-and-stage-works
+    aliases:
+      - Nixon in China
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-death-of-klinghoffer
+    composer_id: john-adams
+    canonical_title: The Death of Klinghoffer
+    localized_titles:
+      en: The Death of Klinghoffer
+      nl: The Death of Klinghoffer
+    year: 1991
+    category: operas-and-stage-works
+    aliases:
+      - Death of Klinghoffer
+      - The Death of Klinghoffer
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-i-was-looking-at-the-ceiling
+    composer_id: john-adams
+    canonical_title: I Was Looking at the Ceiling and Then I Saw the Sky
+    localized_titles:
+      en: I Was Looking at the Ceiling and Then I Saw the Sky
+      nl: I Was Looking at the Ceiling and Then I Saw the Sky
+    year: 1995
+    category: operas-and-stage-works
+    aliases:
+      - I Was Looking at the Ceiling and Then I Saw the Sky
+      - I Was Looking at the Ceiling
+      - Ceiling/Sky
+      - song play
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-el-nino
+    composer_id: john-adams
+    canonical_title: El Niño
+    localized_titles:
+      en: El Niño
+      nl: El Niño
+    year: 2000
+    category: operas-and-stage-works
+    aliases:
+      - El Niño
+      - El Nino
+      - opera-oratorio
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-doctor-atomic
+    composer_id: john-adams
+    canonical_title: Doctor Atomic
+    localized_titles:
+      en: Doctor Atomic
+      nl: Doctor Atomic
+    year: 2005
+    category: operas-and-stage-works
+    aliases:
+      - Doctor Atomic
+      - Dr. Atomic
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-flowering-tree
+    composer_id: john-adams
+    canonical_title: A Flowering Tree
+    localized_titles:
+      en: A Flowering Tree
+      nl: A Flowering Tree
+    year: 2006
+    category: operas-and-stage-works
+    aliases:
+      - A Flowering Tree
+      - Flowering Tree
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-gospel-according-to-the-other-mary
+    composer_id: john-adams
+    canonical_title: The Gospel According to the Other Mary
+    localized_titles:
+      en: The Gospel According to the Other Mary
+      nl: The Gospel According to the Other Mary
+    year: 2013
+    category: operas-and-stage-works
+    aliases:
+      - The Gospel According to the Other Mary
+      - Gospel According to the Other Mary
+      - opera-oratorio
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-girls-of-the-golden-west
+    composer_id: john-adams
+    canonical_title: Girls of the Golden West
+    localized_titles:
+      en: Girls of the Golden West
+      nl: Girls of the Golden West
+    year: 2017
+    category: operas-and-stage-works
+    aliases:
+      - Girls of the Golden West
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-antony-and-cleopatra
+    composer_id: john-adams
+    canonical_title: Antony and Cleopatra
+    localized_titles:
+      en: Antony and Cleopatra
+      nl: Antony and Cleopatra
+    year: 2022
+    category: operas-and-stage-works
+    aliases:
+      - Antony and Cleopatra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-common-tones-in-simple-time
+    composer_id: john-adams
+    canonical_title: Common Tones in Simple Time
+    localized_titles:
+      en: Common Tones in Simple Time
+      nl: Common Tones in Simple Time
+    year: 1979
+    category: orchestral
+    aliases:
+      - Common Tones in Simple Time
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-grand-pianola-music
+    composer_id: john-adams
+    canonical_title: Grand Pianola Music
+    localized_titles:
+      en: Grand Pianola Music
+      nl: Grand Pianola Music
+    year: 1982
+    category: orchestral
+    aliases:
+      - Grand Pianola Music
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-shaker-loops-string-orchestra
+    composer_id: john-adams
+    canonical_title: Shaker Loops
+    localized_titles:
+      en: Shaker Loops
+      nl: Shaker Loops
+    year: 1983
+    category: orchestral
+    aliases:
+      - Shaker Loops
+      - Shaker Loops for string orchestra
+      - adaptation of the 1978 string septet for string orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+    notes: >-
+      Orchestral adaptation of the 1978 string septet, modelled separately from the chamber version.
+
+  - id: adams-harmonielehre
+    composer_id: john-adams
+    canonical_title: Harmonielehre
+    localized_titles:
+      en: Harmonielehre
+      nl: Harmonielehre
+    year: 1985
+    category: orchestral
+    aliases:
+      - Harmonielehre
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-chairman-dances
+    composer_id: john-adams
+    canonical_title: The Chairman Dances
+    localized_titles:
+      en: The Chairman Dances
+      nl: The Chairman Dances
+    year: 1985
+    category: orchestral
+    aliases:
+      - The Chairman Dances
+      - Chairman Dances
+      - Foxtrot for Orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-tromba-lontana
+    composer_id: john-adams
+    canonical_title: Tromba Lontana
+    localized_titles:
+      en: Tromba Lontana
+      nl: Tromba Lontana
+    year: 1986
+    category: orchestral
+    aliases:
+      - Tromba Lontana
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-short-ride-in-a-fast-machine
+    composer_id: john-adams
+    canonical_title: Short Ride in a Fast Machine
+    localized_titles:
+      en: Short Ride in a Fast Machine
+      nl: Short Ride in a Fast Machine
+    year: 1986
+    category: orchestral
+    aliases:
+      - Short Ride in a Fast Machine
+      - Fanfare for Orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-fearful-symmetries
+    composer_id: john-adams
+    canonical_title: Fearful Symmetries
+    localized_titles:
+      en: Fearful Symmetries
+      nl: Fearful Symmetries
+    year: 1988
+    category: orchestral
+    aliases:
+      - Fearful Symmetries
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-el-dorado
+    composer_id: john-adams
+    canonical_title: El Dorado
+    localized_titles:
+      en: El Dorado
+      nl: El Dorado
+    year: 1991
+    category: orchestral
+    aliases:
+      - El Dorado
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-lollapalooza
+    composer_id: john-adams
+    canonical_title: Lollapalooza
+    localized_titles:
+      en: Lollapalooza
+      nl: Lollapalooza
+    year: 1995
+    category: orchestral
+    aliases:
+      - Lollapalooza
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-slonimskys-earbox
+    composer_id: john-adams
+    canonical_title: Slonimsky's Earbox
+    localized_titles:
+      en: Slonimsky's Earbox
+      nl: Slonimsky's Earbox
+    year: 1996
+    category: orchestral
+    aliases:
+      - Slonimsky's Earbox
+      - Slonimskys Earbox
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-naive-and-sentimental-music
+    composer_id: john-adams
+    canonical_title: Naïve and Sentimental Music
+    localized_titles:
+      en: Naïve and Sentimental Music
+      nl: Naïve and Sentimental Music
+    year: 1998
+    category: orchestral
+    aliases:
+      - Naïve and Sentimental Music
+      - Naive and Sentimental Music
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-guide-to-strange-places
+    composer_id: john-adams
+    canonical_title: Guide to Strange Places
+    localized_titles:
+      en: Guide to Strange Places
+      nl: Guide to Strange Places
+    year: 2001
+    category: orchestral
+    aliases:
+      - Guide to Strange Places
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-my-father-knew-charles-ives
+    composer_id: john-adams
+    canonical_title: My Father Knew Charles Ives
+    localized_titles:
+      en: My Father Knew Charles Ives
+      nl: My Father Knew Charles Ives
+    year: 2003
+    category: orchestral
+    aliases:
+      - My Father Knew Charles Ives
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-doctor-atomic-symphony
+    composer_id: john-adams
+    canonical_title: Doctor Atomic Symphony
+    localized_titles:
+      en: Doctor Atomic Symphony
+      nl: Doctor Atomic Symphony
+    year: 2007
+    category: orchestral
+    aliases:
+      - Doctor Atomic Symphony
+      - Dr. Atomic Symphony
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-city-noir
+    composer_id: john-adams
+    canonical_title: City Noir
+    localized_titles:
+      en: City Noir
+      nl: City Noir
+    year: 2009
+    category: orchestral
+    aliases:
+      - City Noir
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-i-still-dance
+    composer_id: john-adams
+    canonical_title: I Still Dance
+    localized_titles:
+      en: I Still Dance
+      nl: I Still Dance
+    year: 2019
+    category: orchestral
+    aliases:
+      - I Still Dance
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-frenzy
+    composer_id: john-adams
+    canonical_title: Frenzy
+    localized_titles:
+      en: Frenzy
+      nl: Frenzy
+    year: 2023
+    category: orchestral
+    aliases:
+      - Frenzy
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-eros-piano
+    composer_id: john-adams
+    canonical_title: Eros Piano
+    localized_titles:
+      en: Eros Piano
+      nl: Eros Piano
+    year: 1989
+    category: concertante
+    aliases:
+      - Eros Piano
+      - Eros Piano for piano and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-century-rolls
+    composer_id: john-adams
+    canonical_title: Century Rolls
+    localized_titles:
+      en: Century Rolls
+      nl: Century Rolls
+    year: 1997
+    category: concertante
+    aliases:
+      - Century Rolls
+      - Concerto for piano and orchestra
+      - Century Rolls concerto for piano and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-must-the-devil-have-all-the-good-tunes
+    composer_id: john-adams
+    canonical_title: Must the Devil Have All the Good Tunes?
+    localized_titles:
+      en: Must the Devil Have All the Good Tunes?
+      nl: Must the Devil Have All the Good Tunes?
+    year: 2018
+    category: concertante
+    aliases:
+      - Must the Devil Have All the Good Tunes?
+      - Must the Devil Have All the Good Tunes
+      - concerto for piano and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-after-the-fall
+    composer_id: john-adams
+    canonical_title: After the Fall
+    localized_titles:
+      en: After the Fall
+      nl: After the Fall
+    year: 2024
+    category: concertante
+    aliases:
+      - After the Fall
+      - concerto for piano and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-violin-concerto
+    composer_id: john-adams
+    canonical_title: Violin Concerto
+    localized_titles:
+      en: Violin Concerto
+      nl: Vioolconcert
+    year: 1993
+    category: concertante
+    aliases:
+      - Violin Concerto
+      - Violin Concerto, 1993
+      - Vioolconcert
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-dharma-at-big-sur
+    composer_id: john-adams
+    canonical_title: The Dharma at Big Sur
+    localized_titles:
+      en: The Dharma at Big Sur
+      nl: The Dharma at Big Sur
+    year: 2003
+    category: concertante
+    aliases:
+      - The Dharma at Big Sur
+      - Dharma at Big Sur
+      - concerto for solo electric violin and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-scheherazade-2
+    composer_id: john-adams
+    canonical_title: Scheherazade.2
+    localized_titles:
+      en: Scheherazade.2
+      nl: Scheherazade.2
+    year: 2014
+    category: concertante
+    aliases:
+      - Scheherazade.2
+      - Scheherazade 2
+      - dramatic symphony for violin and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-absolute-jest
+    composer_id: john-adams
+    canonical_title: Absolute Jest
+    localized_titles:
+      en: Absolute Jest
+      nl: Absolute Jest
+    year: 2012
+    category: concertante
+    aliases:
+      - Absolute Jest
+      - for string quartet and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-saxophone-concerto
+    composer_id: john-adams
+    canonical_title: Saxophone Concerto
+    localized_titles:
+      en: Saxophone Concerto
+      nl: Saxofoonconcert
+    year: 2013
+    category: concertante
+    aliases:
+      - Saxophone Concerto
+      - Saxofoonconcert
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-ktaadn
+    composer_id: john-adams
+    canonical_title: Ktaadn
+    localized_titles:
+      en: Ktaadn
+      nl: Ktaadn
+    year: 1974
+    category: vocal-and-choral
+    aliases:
+      - Ktaadn
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-harmonium
+    composer_id: john-adams
+    canonical_title: Harmonium
+    localized_titles:
+      en: Harmonium
+      nl: Harmonium
+    year: 1980
+    category: vocal-and-choral
+    aliases:
+      - Harmonium
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-nixon-tapes
+    composer_id: john-adams
+    canonical_title: The Nixon Tapes
+    localized_titles:
+      en: The Nixon Tapes
+      nl: The Nixon Tapes
+    year: 1987
+    category: vocal-and-choral
+    aliases:
+      - The Nixon Tapes
+      - Nixon Tapes
+      - three suites from Nixon in China
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-wound-dresser
+    composer_id: john-adams
+    canonical_title: The Wound-Dresser
+    localized_titles:
+      en: The Wound-Dresser
+      nl: The Wound-Dresser
+    year: 1989
+    category: vocal-and-choral
+    aliases:
+      - The Wound-Dresser
+      - Wound-Dresser
+      - The Wound Dresser
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-choruses-from-death-of-klinghoffer
+    composer_id: john-adams
+    canonical_title: Choruses from The Death of Klinghoffer
+    localized_titles:
+      en: Choruses from The Death of Klinghoffer
+      nl: Choruses from The Death of Klinghoffer
+    year: 1991
+    category: vocal-and-choral
+    aliases:
+      - Choruses from The Death of Klinghoffer
+      - Klinghoffer Choruses
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-on-the-transmigration-of-souls
+    composer_id: john-adams
+    canonical_title: On the Transmigration of Souls
+    localized_titles:
+      en: On the Transmigration of Souls
+      nl: On the Transmigration of Souls
+    year: 2002
+    category: vocal-and-choral
+    aliases:
+      - On the Transmigration of Souls
+      - Transmigration of Souls
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-piano-quintet
+    composer_id: john-adams
+    canonical_title: Piano Quintet
+    localized_titles:
+      en: Piano Quintet
+      nl: Pianokwintet
+    year: 1970
+    category: chamber-music
+    aliases:
+      - Piano Quintet
+      - Pianokwintet
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-wavemaker
+    composer_id: john-adams
+    canonical_title: Wavemaker
+    localized_titles:
+      en: Wavemaker
+      nl: Wavemaker
+    year: 1975
+    category: chamber-music
+    aliases:
+      - Wavemaker
+      - for string quartet, voices, tape, and live electronics
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-shaker-loops-string-septet
+    composer_id: john-adams
+    canonical_title: Shaker Loops
+    localized_titles:
+      en: Shaker Loops
+      nl: Shaker Loops
+    year: 1978
+    category: chamber-music
+    aliases:
+      - Shaker Loops
+      - Shaker Loops for string septet
+      - Revised version of Wavemaker
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+    notes: >-
+      Chamber version for string septet, modelled separately from the string orchestra adaptation.
+
+  - id: adams-chamber-symphony
+    composer_id: john-adams
+    canonical_title: Chamber Symphony
+    localized_titles:
+      en: Chamber Symphony
+      nl: Chamber Symphony
+    year: 1992
+    category: chamber-music
+    aliases:
+      - Chamber Symphony
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-johns-book-of-alleged-dances
+    composer_id: john-adams
+    canonical_title: John's Book of Alleged Dances
+    localized_titles:
+      en: John's Book of Alleged Dances
+      nl: John's Book of Alleged Dances
+    year: 1994
+    category: chamber-music
+    aliases:
+      - John's Book of Alleged Dances
+      - Johns Book of Alleged Dances
+      - Alleged Dances
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-road-movies
+    composer_id: john-adams
+    canonical_title: Road Movies
+    localized_titles:
+      en: Road Movies
+      nl: Road Movies
+    year: 1995
+    category: chamber-music
+    aliases:
+      - Road Movies
+      - Road Movies for violin and piano
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-gnarly-buttons
+    composer_id: john-adams
+    canonical_title: Gnarly Buttons
+    localized_titles:
+      en: Gnarly Buttons
+      nl: Gnarly Buttons
+    year: 1996
+    category: chamber-music
+    aliases:
+      - Gnarly Buttons
+      - for clarinet and chamber ensemble
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-son-of-chamber-symphony
+    composer_id: john-adams
+    canonical_title: Son of Chamber Symphony
+    localized_titles:
+      en: Son of Chamber Symphony
+      nl: Son of Chamber Symphony
+    year: 2007
+    category: chamber-music
+    aliases:
+      - Son of Chamber Symphony
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-fellow-traveler
+    composer_id: john-adams
+    canonical_title: Fellow Traveler
+    localized_titles:
+      en: Fellow Traveler
+      nl: Fellow Traveler
+    year: 2007
+    category: chamber-music
+    aliases:
+      - Fellow Traveler
+      - for string quartet
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-first-quartet
+    composer_id: john-adams
+    canonical_title: First Quartet
+    localized_titles:
+      en: First Quartet
+      nl: Eerste kwartet
+    year: 2008
+    category: chamber-music
+    aliases:
+      - First Quartet
+      - String Quartet No. 1
+      - Eerste kwartet
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-second-quartet
+    composer_id: john-adams
+    canonical_title: Second Quartet
+    localized_titles:
+      en: Second Quartet
+      nl: Tweede kwartet
+    year: 2014
+    category: chamber-music
+    aliases:
+      - Second Quartet
+      - String Quartet No. 2
+      - Tweede kwartet
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-american-standard
+    composer_id: john-adams
+    canonical_title: American Standard
+    localized_titles:
+      en: American Standard
+      nl: American Standard
+    year: 1973
+    category: other-ensemble-works
+    aliases:
+      - American Standard
+      - Christian Zeal and Activity
+      - American Standard, including Christian Zeal and Activity
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-grounding
+    composer_id: john-adams
+    canonical_title: Grounding
+    localized_titles:
+      en: Grounding
+      nl: Grounding
+    year: 1975
+    category: other-ensemble-works
+    aliases:
+      - Grounding
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-scratchband
+    composer_id: john-adams
+    canonical_title: Scratchband
+    localized_titles:
+      en: Scratchband
+      nl: Scratchband
+    year: 1996
+    category: other-ensemble-works
+    aliases:
+      - Scratchband
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-nancys-fancy
+    composer_id: john-adams
+    canonical_title: Nancy's Fancy
+    localized_titles:
+      en: Nancy's Fancy
+      nl: Nancy's Fancy
+    year: 2001
+    category: other-ensemble-works
+    aliases:
+      - Nancy's Fancy
+      - Nancys Fancy
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-heavy-metal
+    composer_id: john-adams
+    canonical_title: Heavy Metal
+    localized_titles:
+      en: Heavy Metal
+      nl: Heavy Metal
+    year: 1970
+    category: tape-and-electronic-compositions
+    aliases:
+      - Heavy Metal
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-hockey-seen
+    composer_id: john-adams
+    canonical_title: 'Hockey Seen: A Nightmare in Three Periods and Sudden Death'
+    localized_titles:
+      en: 'Hockey Seen: A Nightmare in Three Periods and Sudden Death'
+      nl: 'Hockey Seen: A Nightmare in Three Periods and Sudden Death'
+    year: 1972
+    category: tape-and-electronic-compositions
+    aliases:
+      - Hockey Seen
+      - A Nightmare in Three Periods and Sudden Death
+      - 'Hockey Seen: A Nightmare in Three Periods and Sudden Death'
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-studebaker-love-music
+    composer_id: john-adams
+    canonical_title: Studebaker Love Music
+    localized_titles:
+      en: Studebaker Love Music
+      nl: Studebaker Love Music
+    year: 1976
+    category: tape-and-electronic-compositions
+    aliases:
+      - Studebaker Love Music
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-onyx
+    composer_id: john-adams
+    canonical_title: Onyx
+    localized_titles:
+      en: Onyx
+      nl: Onyx
+    year: 1976
+    category: tape-and-electronic-compositions
+    aliases:
+      - Onyx
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-light-over-water
+    composer_id: john-adams
+    canonical_title: Light Over Water
+    localized_titles:
+      en: Light Over Water
+      nl: Light Over Water
+    year: 1983
+    category: tape-and-electronic-compositions
+    aliases:
+      - Light Over Water
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-hoodoo-zephyr
+    composer_id: john-adams
+    canonical_title: Hoodoo Zephyr
+    localized_titles:
+      en: Hoodoo Zephyr
+      nl: Hoodoo Zephyr
+    year: 1993
+    category: tape-and-electronic-compositions
+    aliases:
+      - Hoodoo Zephyr
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-coast
+    composer_id: john-adams
+    canonical_title: Coast
+    localized_titles:
+      en: Coast
+      nl: Coast
+    category: tape-and-electronic-compositions
+    aliases:
+      - Coast
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-disappointment-lake
+    composer_id: john-adams
+    canonical_title: Disappointment Lake
+    localized_titles:
+      en: Disappointment Lake
+      nl: Disappointment Lake
+    category: tape-and-electronic-compositions
+    aliases:
+      - Disappointment Lake
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-tourist-song
+    composer_id: john-adams
+    canonical_title: Tourist Song
+    localized_titles:
+      en: Tourist Song
+      nl: Tourist Song
+    category: tape-and-electronic-compositions
+    aliases:
+      - Tourist Song
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-tundra
+    composer_id: john-adams
+    canonical_title: Tundra
+    localized_titles:
+      en: Tundra
+      nl: Tundra
+    category: tape-and-electronic-compositions
+    aliases:
+      - Tundra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-bump
+    composer_id: john-adams
+    canonical_title: Bump
+    localized_titles:
+      en: Bump
+      nl: Bump
+    category: tape-and-electronic-compositions
+    aliases:
+      - Bump
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-cerulean
+    composer_id: john-adams
+    canonical_title: Cerulean
+    localized_titles:
+      en: Cerulean
+      nl: Cerulean
+    category: tape-and-electronic-compositions
+    aliases:
+      - Cerulean
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-ragamarole
+    composer_id: john-adams
+    canonical_title: Ragamarole
+    localized_titles:
+      en: Ragamarole
+      nl: Ragamarole
+    year: 1973
+    category: piano
+    aliases:
+      - Ragamarole
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-blue-light
+    composer_id: john-adams
+    canonical_title: Blue Light
+    localized_titles:
+      en: Blue Light
+      nl: Blue Light
+    year: 1976
+    category: piano
+    aliases:
+      - Blue Light
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-a-fox-at-forty
+    composer_id: john-adams
+    canonical_title: A Fox at Forty
+    localized_titles:
+      en: A Fox at Forty
+      nl: A Fox at Forty
+    year: 1978
+    category: piano
+    aliases:
+      - A Fox at Forty
+      - Fox at Forty
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-phrygian-gates
+    composer_id: john-adams
+    canonical_title: Phrygian Gates
+    localized_titles:
+      en: Phrygian Gates
+      nl: Phrygian Gates
+    year: 1977
+    category: piano
+    aliases:
+      - Phrygian Gates
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-china-gates
+    composer_id: john-adams
+    canonical_title: China Gates
+    localized_titles:
+      en: China Gates
+      nl: China Gates
+    year: 1977
+    category: piano
+    aliases:
+      - China Gates
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-hallelujah-junction
+    composer_id: john-adams
+    canonical_title: Hallelujah Junction
+    localized_titles:
+      en: Hallelujah Junction
+      nl: Hallelujah Junction
+    year: 1996
+    category: piano
+    aliases:
+      - Hallelujah Junction
+      - for two pianos
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-american-berserk
+    composer_id: john-adams
+    canonical_title: American Berserk
+    localized_titles:
+      en: American Berserk
+      nl: American Berserk
+    year: 2001
+    category: piano
+    aliases:
+      - American Berserk
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-roll-over-beethoven
+    composer_id: john-adams
+    canonical_title: Roll Over Beethoven
+    localized_titles:
+      en: Roll Over Beethoven
+      nl: Roll Over Beethoven
+    year: 2014
+    category: piano
+    aliases:
+      - Roll Over Beethoven
+      - for two pianos
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-i-still-play
+    composer_id: john-adams
+    canonical_title: I Still Play
+    localized_titles:
+      en: I Still Play
+      nl: I Still Play
+    year: 2017
+    category: piano
+    aliases:
+      - I Still Play
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-matter-of-heart
+    composer_id: john-adams
+    canonical_title: Matter of Heart
+    localized_titles:
+      en: Matter of Heart
+      nl: Matter of Heart
+    year: 1982
+    category: film-scores
+    aliases:
+      - Matter of Heart
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-cabinet-of-dr-ramirez
+    composer_id: john-adams
+    canonical_title: The Cabinet of Dr. Ramirez
+    localized_titles:
+      en: The Cabinet of Dr. Ramirez
+      nl: The Cabinet of Dr. Ramirez
+    year: 1991
+    category: film-scores
+    aliases:
+      - The Cabinet of Dr. Ramirez
+      - Cabinet of Dr. Ramirez
+      - The Cabinet of Doctor Ramirez
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-american-tapestry
+    composer_id: john-adams
+    canonical_title: American Tapestry
+    localized_titles:
+      en: American Tapestry
+      nl: American Tapestry
+    year: 1999
+    category: film-scores
+    aliases:
+      - American Tapestry
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-i-am-love
+    composer_id: john-adams
+    canonical_title: I Am Love
+    localized_titles:
+      en: I Am Love
+      it: Io sono l'amore
+      nl: I Am Love
+    year: 2010
+    category: film-scores
+    aliases:
+      - I Am Love
+      - Io sono l'amore
+      - pre-existing pieces by Adams
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: adams-call-me-by-your-name
+    composer_id: john-adams
+    canonical_title: Call Me by Your Name
+    localized_titles:
+      en: Call Me by Your Name
+      nl: Call Me by Your Name
+    year: 2017
+    category: film-scores
+    aliases:
+      - Call Me by Your Name
+      - contributions
+    authorities:
+      musicbrainz_work_id:
+      wikidata:

--- a/data/works/luciano-berio/works.yaml
+++ b/data/works/luciano-berio/works.yaml
@@ -1,0 +1,236 @@
+composer_id: luciano-berio
+source_note: >-
+  Representative pilot set based on the existing docs/berio.md page. It tests modern
+  works without opus numbers, series identities, arrangements, withdrawn/reworked works,
+  and relationships between Sequenza and Chemins works.
+works:
+  - id: berio-folk-songs
+    composer_id: luciano-berio
+    canonical_title: Folk Songs
+    localized_titles: { en: Folk Songs, it: Folk Songs, nl: Folk Songs }
+    year: 1964
+    category: vocal-instrumental
+    aliases: [Folk Songs, Folk Songs for mezzo-soprano and seven instruments, Folk Songs for mezzo-soprano and orchestra]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sinfonia
+    composer_id: luciano-berio
+    canonical_title: Sinfonia
+    localized_titles: { en: Sinfonia, it: Sinfonia, nl: Sinfonia }
+    year: 1968-1969
+    category: orchestral-vocal
+    aliases: [Sinfonia, Sinfonia for eight voices and orchestra, O King]
+    authorities: { musicbrainz_work_id:, wikidata: }
+    notes: >-
+      Includes material from O King; the fifth movement was added after the original version.
+  - id: berio-laborintus-ii
+    composer_id: luciano-berio
+    canonical_title: Laborintus II
+    localized_titles: { en: Laborintus II, it: Laborintus II, nl: Laborintus II }
+    year: 1965
+    category: stage-vocal-instrumental
+    aliases: [Laborintus II, Laborintus 2]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-i
+    composer_id: luciano-berio
+    canonical_title: Sequenza I
+    localized_titles: { en: Sequenza I, it: Sequenza I, nl: Sequenza I }
+    year: 1958
+    category: solo
+    aliases: [Sequenza I, Sequenza 1, Sequenza I for flute]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-ii
+    composer_id: luciano-berio
+    canonical_title: Sequenza II
+    localized_titles: { en: Sequenza II, it: Sequenza II, nl: Sequenza II }
+    year: 1963
+    category: solo
+    aliases: [Sequenza II, Sequenza 2, Sequenza II for harp]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-iii
+    composer_id: luciano-berio
+    canonical_title: Sequenza III
+    localized_titles: { en: Sequenza III, it: Sequenza III, nl: Sequenza III }
+    year: 1966
+    category: solo
+    aliases: [Sequenza III, Sequenza 3, Sequenza III for solo voice]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-iv
+    composer_id: luciano-berio
+    canonical_title: Sequenza IV
+    localized_titles: { en: Sequenza IV, it: Sequenza IV, nl: Sequenza IV }
+    year: 1966
+    category: solo
+    aliases: [Sequenza IV, Sequenza 4, Sequenza IV for piano]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-v
+    composer_id: luciano-berio
+    canonical_title: Sequenza V
+    localized_titles: { en: Sequenza V, it: Sequenza V, nl: Sequenza V }
+    year: 1966
+    category: solo
+    aliases: [Sequenza V, Sequenza 5, Sequenza V for trombone]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-vi
+    composer_id: luciano-berio
+    canonical_title: Sequenza VI
+    localized_titles: { en: Sequenza VI, it: Sequenza VI, nl: Sequenza VI }
+    year: 1967
+    category: solo
+    aliases: [Sequenza VI, Sequenza 6, Sequenza VI for viola]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-vii-a
+    composer_id: luciano-berio
+    canonical_title: Sequenza VIIa
+    localized_titles: { en: Sequenza VIIa, it: Sequenza VIIa, nl: Sequenza VIIa }
+    year: 1969
+    category: solo
+    aliases: [Sequenza VIIa, Sequenza VII for oboe, Sequenza 7a]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-viii
+    composer_id: luciano-berio
+    canonical_title: Sequenza VIII
+    localized_titles: { en: Sequenza VIII, it: Sequenza VIII, nl: Sequenza VIII }
+    year: 1976
+    category: solo
+    aliases: [Sequenza VIII, Sequenza 8, Sequenza VIII for violin]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-ix-a
+    composer_id: luciano-berio
+    canonical_title: Sequenza IXa
+    localized_titles: { en: Sequenza IXa, it: Sequenza IXa, nl: Sequenza IXa }
+    year: 1980
+    category: solo
+    aliases: [Sequenza IXa, Sequenza IX for clarinet, Sequenza 9a]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-x
+    composer_id: luciano-berio
+    canonical_title: Sequenza X
+    localized_titles: { en: Sequenza X, it: Sequenza X, nl: Sequenza X }
+    year: 1984
+    category: solo
+    aliases: [Sequenza X, Sequenza 10, Sequenza X for trumpet]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-xi
+    composer_id: luciano-berio
+    canonical_title: Sequenza XI
+    localized_titles: { en: Sequenza XI, it: Sequenza XI, nl: Sequenza XI }
+    year: 1988
+    category: solo
+    aliases: [Sequenza XI, Sequenza 11, Sequenza XI for guitar]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-xii
+    composer_id: luciano-berio
+    canonical_title: Sequenza XII
+    localized_titles: { en: Sequenza XII, it: Sequenza XII, nl: Sequenza XII }
+    year: 1995
+    category: solo
+    aliases: [Sequenza XII, Sequenza 12, Sequenza XII for bassoon]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-xiii
+    composer_id: luciano-berio
+    canonical_title: Sequenza XIII
+    localized_titles: { en: Sequenza XIII, it: Sequenza XIII, nl: Sequenza XIII }
+    year: 1995
+    category: solo
+    aliases: [Sequenza XIII, Sequenza 13, Chanson for accordion]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sequenza-xiv
+    composer_id: luciano-berio
+    canonical_title: Sequenza XIV
+    localized_titles: { en: Sequenza XIV, it: Sequenza XIV, nl: Sequenza XIV }
+    year: 2002
+    category: solo
+    aliases: [Sequenza XIV, Sequenza 14, Sequenza XIV for cello]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-chemins-i
+    composer_id: luciano-berio
+    canonical_title: Chemins I
+    localized_titles: { en: Chemins I, it: Chemins I, nl: Chemins I }
+    year: 1964
+    category: concertante
+    aliases: [Chemins I, Chemins 1, Chemins I for harp and orchestra]
+    authorities: { musicbrainz_work_id:, wikidata: }
+    notes: >-
+      Related to Sequenza II.
+  - id: berio-chemins-ii
+    composer_id: luciano-berio
+    canonical_title: Chemins II
+    localized_titles: { en: Chemins II, it: Chemins II, nl: Chemins II }
+    year: 1967
+    category: concertante
+    aliases: [Chemins II, Chemins 2, Chemins II for viola and nine instruments]
+    authorities: { musicbrainz_work_id:, wikidata: }
+    notes: >-
+      Related to Sequenza VI.
+  - id: berio-chemins-iii
+    composer_id: luciano-berio
+    canonical_title: Chemins III
+    localized_titles: { en: Chemins III, it: Chemins III, nl: Chemins III }
+    year: 1968
+    category: concertante
+    aliases: [Chemins III, Chemins 3]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-chemins-iv
+    composer_id: luciano-berio
+    canonical_title: Chemins IV
+    localized_titles: { en: Chemins IV, it: Chemins IV, nl: Chemins IV }
+    year: 1975
+    category: concertante
+    aliases: [Chemins IV, Chemins 4, Chemins IV for oboe and strings]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-coro
+    composer_id: luciano-berio
+    canonical_title: Coro
+    localized_titles: { en: Coro, it: Coro, nl: Coro }
+    year: 1976-1977
+    category: vocal-instrumental
+    aliases: [Coro, Coro for forty voices and instruments]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-voci
+    composer_id: luciano-berio
+    canonical_title: Voci
+    localized_titles: { en: Voci, it: Voci, nl: Voci }
+    year: 1984
+    category: concertante
+    aliases: [Voci, Voci for viola and orchestra]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-naturale
+    composer_id: luciano-berio
+    canonical_title: Naturale
+    localized_titles: { en: Naturale, it: Naturale, nl: Naturale }
+    year: 1985
+    category: chamber
+    aliases: [Naturale, Naturale for viola, percussion and recordings]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-rendering
+    composer_id: luciano-berio
+    canonical_title: Rendering
+    localized_titles: { en: Rendering, it: Rendering, nl: Rendering }
+    year: 1990
+    category: orchestral
+    aliases: [Rendering, Rendering after Schubert, Schubert Tenth Symphony sketches]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-six-encores
+    composer_id: luciano-berio
+    canonical_title: Six Encores
+    localized_titles: { en: Six Encores, it: Six Encores, nl: Six Encores }
+    year: 1990
+    category: piano
+    aliases: [Six Encores, Brin, Leaf, Wasserklavier, Erdenklavier, Luftklavier, Feuerklavier]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-sonata-for-piano
+    composer_id: luciano-berio
+    canonical_title: Sonata for Piano
+    localized_titles: { en: Sonata for Piano, it: Sonata per pianoforte, nl: Pianosonate }
+    year: 2001
+    category: piano
+    aliases: [Sonata for piano, Sonata per pianoforte, Piano Sonata]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: berio-stanze
+    composer_id: luciano-berio
+    canonical_title: Stanze
+    localized_titles: { en: Stanze, it: Stanze, nl: Stanze }
+    year: 2003
+    category: vocal-orchestral
+    aliases: [Stanze, Stanze for baritone, chorus and orchestra]
+    authorities: { musicbrainz_work_id:, wikidata: }

--- a/data/works/ludwig-van-beethoven/works.yaml
+++ b/data/works/ludwig-van-beethoven/works.yaml
@@ -1,0 +1,270 @@
+composer_id: ludwig-van-beethoven
+source_note: >-
+  Representative pilot set based on the existing docs/beethoven.md page. It covers opus,
+  WoO and Hess identifiers, nicknames, arrangements, symphonies, concertos, quartets,
+  sonatas and stage works.
+works:
+  - id: beethoven-op15
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Concerto No. 1 in C major
+    localized_titles: { en: Piano Concerto No. 1 in C major, de: Klavierkonzert Nr. 1 C-Dur, nl: Pianoconcert nr. 1 in C groot }
+    category: orchestral
+    catalogue: { opus: Op. 15 }
+    aliases: [Piano Concerto No. 1, Klavierkonzert Nr. 1, Op. 15]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op19
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Concerto No. 2 in B-flat major
+    localized_titles: { en: Piano Concerto No. 2 in B-flat major, de: Klavierkonzert Nr. 2 B-Dur, nl: Pianoconcert nr. 2 in Bes groot }
+    category: orchestral
+    catalogue: { opus: Op. 19 }
+    aliases: [Piano Concerto No. 2, Klavierkonzert Nr. 2, Op. 19]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op21
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 1 in C major
+    localized_titles: { en: Symphony No. 1 in C major, de: Sinfonie Nr. 1 C-Dur, nl: Symfonie nr. 1 in C groot }
+    category: orchestral
+    catalogue: { opus: Op. 21 }
+    aliases: [Symphony No. 1, First Symphony, Op. 21]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op36
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 2 in D major
+    localized_titles: { en: Symphony No. 2 in D major, de: Sinfonie Nr. 2 D-Dur, nl: Symfonie nr. 2 in D groot }
+    category: orchestral
+    catalogue: { opus: Op. 36 }
+    aliases: [Symphony No. 2, Second Symphony, Op. 36]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op37
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Concerto No. 3 in C minor
+    localized_titles: { en: Piano Concerto No. 3 in C minor, de: Klavierkonzert Nr. 3 c-Moll, nl: Pianoconcert nr. 3 in c klein }
+    category: orchestral
+    catalogue: { opus: Op. 37 }
+    aliases: [Piano Concerto No. 3, Klavierkonzert Nr. 3, Op. 37]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op43
+    composer_id: ludwig-van-beethoven
+    canonical_title: The Creatures of Prometheus
+    localized_titles: { en: The Creatures of Prometheus, de: Die Geschöpfe des Prometheus, nl: De schepselen van Prometheus }
+    category: stage-orchestral
+    catalogue: { opus: Op. 43 }
+    aliases: [The Creatures of Prometheus, Die Geschöpfe des Prometheus, Prometheus, Op. 43]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op55
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 3 in E-flat major, Eroica
+    localized_titles: { en: Symphony No. 3 in E-flat major, Eroica, de: Sinfonie Nr. 3 Es-Dur, Eroica, nl: Symfonie nr. 3 in Es groot, Eroica }
+    category: orchestral
+    catalogue: { opus: Op. 55 }
+    aliases: [Symphony No. 3, Eroica, Third Symphony, Op. 55]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op56
+    composer_id: ludwig-van-beethoven
+    canonical_title: Triple Concerto in C major
+    localized_titles: { en: Triple Concerto in C major, de: Tripelkonzert C-Dur, nl: Tripelconcert in C groot }
+    category: orchestral
+    catalogue: { opus: Op. 56 }
+    aliases: [Triple Concerto, Concerto for violin, cello and piano, Op. 56]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op58
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Concerto No. 4 in G major
+    localized_titles: { en: Piano Concerto No. 4 in G major, de: Klavierkonzert Nr. 4 G-Dur, nl: Pianoconcert nr. 4 in G groot }
+    category: orchestral
+    catalogue: { opus: Op. 58 }
+    aliases: [Piano Concerto No. 4, Klavierkonzert Nr. 4, Op. 58]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op60
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 4 in B-flat major
+    localized_titles: { en: Symphony No. 4 in B-flat major, de: Sinfonie Nr. 4 B-Dur, nl: Symfonie nr. 4 in Bes groot }
+    category: orchestral
+    catalogue: { opus: Op. 60 }
+    aliases: [Symphony No. 4, Fourth Symphony, Op. 60]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op61
+    composer_id: ludwig-van-beethoven
+    canonical_title: Violin Concerto in D major
+    localized_titles: { en: Violin Concerto in D major, de: Violinkonzert D-Dur, nl: Vioolconcert in D groot }
+    category: orchestral
+    catalogue: { opus: Op. 61 }
+    aliases: [Violin Concerto, Violinkonzert, Op. 61]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op61a
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Concerto in D major after the Violin Concerto
+    localized_titles: { en: Piano Concerto in D major after the Violin Concerto, nl: Pianoversie van het vioolconcert }
+    category: orchestral
+    catalogue: { opus: Op. 61a }
+    aliases: [Arrangement of Op. 61 for Piano, Piano version of the Violin Concerto, Op. 61a]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op67
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 5 in C minor
+    localized_titles: { en: Symphony No. 5 in C minor, de: Sinfonie Nr. 5 c-Moll, nl: Symfonie nr. 5 in c klein }
+    category: orchestral
+    catalogue: { opus: Op. 67 }
+    aliases: [Symphony No. 5, Fifth Symphony, Fate Symphony, Schicksalssinfonie, Op. 67]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op68
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 6 in F major, Pastoral
+    localized_titles: { en: Symphony No. 6 in F major, Pastoral, de: Sinfonie Nr. 6 F-Dur, Pastorale, nl: Symfonie nr. 6 in F groot, Pastorale }
+    category: orchestral
+    catalogue: { opus: Op. 68 }
+    aliases: [Symphony No. 6, Pastoral Symphony, Pastorale, Op. 68]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op73
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Concerto No. 5 in E-flat major, Emperor
+    localized_titles: { en: Piano Concerto No. 5 in E-flat major, Emperor, de: Klavierkonzert Nr. 5 Es-Dur, nl: Pianoconcert nr. 5 in Es groot }
+    category: orchestral
+    catalogue: { opus: Op. 73 }
+    aliases: [Piano Concerto No. 5, Emperor Concerto, Emperor, Op. 73]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op84
+    composer_id: ludwig-van-beethoven
+    canonical_title: Egmont
+    localized_titles: { en: Egmont, de: Egmont, nl: Egmont }
+    category: stage-orchestral
+    catalogue: { opus: Op. 84 }
+    aliases: [Egmont, Egmont Overture, Egmont-Ouverture, Op. 84]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op92
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 7 in A major
+    localized_titles: { en: Symphony No. 7 in A major, de: Sinfonie Nr. 7 A-Dur, nl: Symfonie nr. 7 in A groot }
+    category: orchestral
+    catalogue: { opus: Op. 92 }
+    aliases: [Symphony No. 7, Seventh Symphony, Op. 92]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op93
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 8 in F major
+    localized_titles: { en: Symphony No. 8 in F major, de: Sinfonie Nr. 8 F-Dur, nl: Symfonie nr. 8 in F groot }
+    category: orchestral
+    catalogue: { opus: Op. 93 }
+    aliases: [Symphony No. 8, Eighth Symphony, Op. 93]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op125
+    composer_id: ludwig-van-beethoven
+    canonical_title: Symphony No. 9 in D minor, Choral
+    localized_titles: { en: Symphony No. 9 in D minor, Choral, de: Sinfonie Nr. 9 d-Moll, nl: Symfonie nr. 9 in d klein }
+    category: orchestral
+    catalogue: { opus: Op. 125 }
+    aliases: [Symphony No. 9, Choral Symphony, Ninth Symphony, Ode to Joy, Op. 125]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op18
+    composer_id: ludwig-van-beethoven
+    canonical_title: Six String Quartets, Op. 18
+    localized_titles: { en: Six String Quartets, Op. 18, nl: Zes strijkkwartetten, Op. 18 }
+    category: chamber
+    catalogue: { opus: Op. 18 }
+    aliases: [String Quartets Op. 18, Six String Quartets, Op. 18]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op59
+    composer_id: ludwig-van-beethoven
+    canonical_title: Three Razumovsky String Quartets
+    localized_titles: { en: Three Razumovsky String Quartets, nl: Drie Razumovsky-strijkkwartetten }
+    category: chamber
+    catalogue: { opus: Op. 59 }
+    aliases: [Razumovsky Quartets, String Quartets Op. 59, Op. 59]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op95
+    composer_id: ludwig-van-beethoven
+    canonical_title: String Quartet No. 11 in F minor, Serioso
+    localized_titles: { en: String Quartet No. 11 in F minor, Serioso, nl: Strijkkwartet nr. 11 in f klein, Serioso }
+    category: chamber
+    catalogue: { opus: Op. 95 }
+    aliases: [String Quartet No. 11, Serioso, Op. 95]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op127
+    composer_id: ludwig-van-beethoven
+    canonical_title: String Quartet No. 12 in E-flat major
+    localized_titles: { en: String Quartet No. 12 in E-flat major, nl: Strijkkwartet nr. 12 in Es groot }
+    category: chamber
+    catalogue: { opus: Op. 127 }
+    aliases: [String Quartet No. 12, Late Quartets, Op. 127]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op130
+    composer_id: ludwig-van-beethoven
+    canonical_title: String Quartet No. 13 in B-flat major
+    localized_titles: { en: String Quartet No. 13 in B-flat major, nl: Strijkkwartet nr. 13 in Bes groot }
+    category: chamber
+    catalogue: { opus: Op. 130 }
+    aliases: [String Quartet No. 13, Late Quartets, Op. 130]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op131
+    composer_id: ludwig-van-beethoven
+    canonical_title: String Quartet No. 14 in C-sharp minor
+    localized_titles: { en: String Quartet No. 14 in C-sharp minor, nl: Strijkkwartet nr. 14 in cis klein }
+    category: chamber
+    catalogue: { opus: Op. 131 }
+    aliases: [String Quartet No. 14, Late Quartets, Op. 131]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op132
+    composer_id: ludwig-van-beethoven
+    canonical_title: String Quartet No. 15 in A minor
+    localized_titles: { en: String Quartet No. 15 in A minor, nl: Strijkkwartet nr. 15 in a klein }
+    category: chamber
+    catalogue: { opus: Op. 132 }
+    aliases: [String Quartet No. 15, Heiliger Dankgesang, Late Quartets, Op. 132]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op133
+    composer_id: ludwig-van-beethoven
+    canonical_title: Große Fuge
+    localized_titles: { en: Grosse Fuge, de: Große Fuge, nl: Grote fuga }
+    category: chamber
+    catalogue: { opus: Op. 133 }
+    aliases: [Große Fuge, Grosse Fuge, Great Fugue, Op. 133]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op135
+    composer_id: ludwig-van-beethoven
+    canonical_title: String Quartet No. 16 in F major
+    localized_titles: { en: String Quartet No. 16 in F major, nl: Strijkkwartet nr. 16 in F groot }
+    category: chamber
+    catalogue: { opus: Op. 135 }
+    aliases: [String Quartet No. 16, Late Quartets, Op. 135]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op13
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Sonata No. 8 in C minor, Pathétique
+    localized_titles: { en: Piano Sonata No. 8 in C minor, Pathétique, nl: Pianosonate nr. 8 in c klein, Pathétique }
+    category: piano
+    catalogue: { opus: Op. 13 }
+    aliases: [Pathétique Sonata, Pathetique, Piano Sonata No. 8, Op. 13]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op27-2
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Sonata No. 14 in C-sharp minor, Moonlight
+    localized_titles: { en: Piano Sonata No. 14 in C-sharp minor, Moonlight, de: Mondscheinsonate, nl: Mondscheinsonate }
+    category: piano
+    catalogue: { opus: Op. 27/2 }
+    aliases: [Moonlight Sonata, Mondscheinsonate, Piano Sonata No. 14, Op. 27 No. 2]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op53
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Sonata No. 21 in C major, Waldstein
+    localized_titles: { en: Piano Sonata No. 21 in C major, Waldstein, nl: Pianosonate nr. 21 in C groot, Waldstein }
+    category: piano
+    catalogue: { opus: Op. 53 }
+    aliases: [Waldstein Sonata, Piano Sonata No. 21, Op. 53]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op57
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Sonata No. 23 in F minor, Appassionata
+    localized_titles: { en: Piano Sonata No. 23 in F minor, Appassionata, nl: Pianosonate nr. 23 in f klein, Appassionata }
+    category: piano
+    catalogue: { opus: Op. 57 }
+    aliases: [Appassionata Sonata, Piano Sonata No. 23, Op. 57]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: beethoven-op106
+    composer_id: ludwig-van-beethoven
+    canonical_title: Piano Sonata No. 29 in B-flat major, Hammerklavier
+    localized_titles: { en: Piano Sonata No. 29 in B-flat major, Hammerklavier, nl: Hammerklavier-sonate }
+    category: piano
+    catalogue: { opus: Op. 106 }
+    aliases: [Hammerklavier Sonata, Piano Sonata No. 29, Op. 106]
+    authorities: { musicbrainz_work_id:, wikidata: }

--- a/data/works/samuel-barber/works.yaml
+++ b/data/works/samuel-barber/works.yaml
@@ -1,0 +1,1096 @@
+composer_id: samuel-barber
+works:
+  - id: barber-op32
+    composer_id: samuel-barber
+    canonical_title: Vanessa
+    localized_titles:
+      en: Vanessa
+      nl: Vanessa
+    year: 1956-1957, 1964
+    category: opera
+    catalogue:
+      opus: Op. 32
+    aliases:
+      - Vanessa
+      - Vanessa, Op. 32
+      - Op. 32
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op35
+    composer_id: samuel-barber
+    canonical_title: A Hand of Bridge
+    localized_titles:
+      en: A Hand of Bridge
+      nl: A Hand of Bridge
+    year: 1959
+    category: opera
+    catalogue:
+      opus: Op. 35
+    aliases:
+      - A Hand of Bridge
+      - A Hand of Bridge, Op. 35
+      - Op. 35
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op40
+    composer_id: samuel-barber
+    canonical_title: Antony and Cleopatra
+    localized_titles:
+      en: Antony and Cleopatra
+      nl: Antony and Cleopatra
+    year: 1966, 1975
+    category: opera
+    catalogue:
+      opus: Op. 40
+    aliases:
+      - Antony and Cleopatra
+      - Antony and Cleopatra, Op. 40
+      - Op. 40
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-serpent-heart
+    composer_id: samuel-barber
+    canonical_title: Serpent Heart
+    localized_titles:
+      en: Serpent Heart
+      nl: Serpent Heart
+    year: 1946
+    category: ballet
+    aliases:
+      - Serpent Heart
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-cave-of-the-heart
+    composer_id: samuel-barber
+    canonical_title: Cave of the Heart
+    localized_titles:
+      en: Cave of the Heart
+      nl: Cave of the Heart
+    year: 1947
+    category: ballet
+    aliases:
+      - Cave of the Heart
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op28-ballet
+    composer_id: samuel-barber
+    canonical_title: Souvenirs
+    localized_titles:
+      en: Souvenirs
+      nl: Souvenirs
+    year: 1955
+    category: ballet
+    catalogue:
+      opus: Op. 28
+    aliases:
+      - Souvenirs
+      - Souvenirs, Op. 28
+      - Op. 28
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+    notes: >-
+      Ballet entry from the current Barber collection page; related piano-suite versions are modelled separately.
+
+  - id: barber-op1-string-orchestra
+    composer_id: samuel-barber
+    canonical_title: Serenade
+    localized_titles:
+      en: Serenade
+      nl: Serenade
+    year: 1944
+    category: orchestral
+    catalogue:
+      opus: Op. 1
+    aliases:
+      - Serenade
+      - Serenade, Op. 1
+      - Serenade for string orchestra
+      - str-orch
+      - Op. 1
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+    notes: >-
+      String-orchestra version, modelled separately from the chamber Serenade listed under chamber music.
+
+  - id: barber-op5
+    composer_id: samuel-barber
+    canonical_title: Overture to The School for Scandal
+    localized_titles:
+      en: Overture to The School for Scandal
+      nl: Overture to The School for Scandal
+    year: 1931
+    category: orchestral
+    catalogue:
+      opus: Op. 5
+    aliases:
+      - Overture to The School for Scandal
+      - The School for Scandal Overture
+      - Overture to "The School for Scandal"
+      - Op. 5
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op7
+    composer_id: samuel-barber
+    canonical_title: Music for a Scene from Shelley
+    localized_titles:
+      en: Music for a Scene from Shelley
+      nl: Music for a Scene from Shelley
+    year: 1933
+    category: orchestral
+    catalogue:
+      opus: Op. 7
+    aliases:
+      - Music for a Scene from Shelley
+      - Music for a Scene from Shelley, Op. 7
+      - Op. 7
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op9
+    composer_id: samuel-barber
+    canonical_title: First Symphony
+    localized_titles:
+      en: First Symphony
+      nl: Eerste symfonie
+    year: 1935-1936, 1942-1943
+    category: orchestral
+    catalogue:
+      opus: Op. 9
+    aliases:
+      - First Symphony
+      - Symphony No. 1
+      - First Symphony in One Movement
+      - Symphony in One Movement
+      - Op. 9
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op11a
+    composer_id: samuel-barber
+    canonical_title: Adagio for Strings
+    localized_titles:
+      en: Adagio for Strings
+      nl: Adagio for Strings
+    year: 1936
+    category: orchestral
+    catalogue:
+      opus: Op. 11a
+    aliases:
+      - Adagio for Strings
+      - Adagio for Strings, Op. 11a
+      - Op. 11a
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+    notes: >-
+      Orchestral arrangement associated with the String Quartet, Op. 11.
+
+  - id: barber-op12
+    composer_id: samuel-barber
+    canonical_title: Essay for Orchestra
+    localized_titles:
+      en: Essay for Orchestra
+      nl: Essay for Orchestra
+    year: 1938
+    category: orchestral
+    catalogue:
+      opus: Op. 12
+    aliases:
+      - Essay for Orchestra
+      - First Essay for Orchestra
+      - Essay for Orchestra No. 1
+      - Op. 12
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op17
+    composer_id: samuel-barber
+    canonical_title: Second Essay for Orchestra
+    localized_titles:
+      en: Second Essay for Orchestra
+      nl: Second Essay for Orchestra
+    year: 1942
+    category: orchestral
+    catalogue:
+      opus: Op. 17
+    aliases:
+      - Second Essay for Orchestra
+      - Essay for Orchestra No. 2
+      - Op. 17
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op19
+    composer_id: samuel-barber
+    canonical_title: Symphony No. 2
+    localized_titles:
+      en: Symphony No. 2
+      nl: Tweede symfonie
+    year: 1944, 1947
+    category: orchestral
+    catalogue:
+      opus: Op. 19
+    aliases:
+      - Symphony No. 2
+      - Second Symphony
+      - Op. 19
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op19a
+    composer_id: samuel-barber
+    canonical_title: Night Flight
+    localized_titles:
+      en: Night Flight
+      nl: Night Flight
+    year: 1964
+    category: orchestral
+    catalogue:
+      opus: Op. 19a
+    aliases:
+      - Night Flight
+      - Night Flight, Tone Poem
+      - Night Flight, Op. 19a
+      - Op. 19a
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-horizon
+    composer_id: samuel-barber
+    canonical_title: Horizon
+    localized_titles:
+      en: Horizon
+      nl: Horizon
+    year: 1945
+    category: orchestral
+    aliases:
+      - Horizon
+      - Horizon for chamber orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op23-suite
+    composer_id: samuel-barber
+    canonical_title: Medea, Suite
+    localized_titles:
+      en: Medea, Suite
+      nl: Medea, suite
+    year: 1947
+    category: orchestral
+    catalogue:
+      opus: Op. 23
+    aliases:
+      - Medea, Suite
+      - Medea Suite
+      - Medea, Op. 23
+      - Op. 23
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op23a
+    composer_id: samuel-barber
+    canonical_title: Medea's Dance of Vengeance
+    localized_titles:
+      en: Medea's Dance of Vengeance
+      nl: Medea's Dance of Vengeance
+    year: 1955
+    category: orchestral
+    catalogue:
+      opus: Op. 23a
+    aliases:
+      - Medea's Dance of Vengeance
+      - Medeas Dance of Vengeance
+      - Medea's Meditation and Dance of Vengeance
+      - Op. 23a
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-vanessa-intermezzo
+    composer_id: samuel-barber
+    canonical_title: Intermezzo from Vanessa
+    localized_titles:
+      en: Intermezzo from Vanessa
+      nl: Intermezzo from Vanessa
+    year: 1958
+    category: orchestral
+    aliases:
+      - Intermezzo from Vanessa
+      - Intermezzo from the Opera Vanessa
+      - Vanessa Intermezzo
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op37
+    composer_id: samuel-barber
+    canonical_title: Die Natali
+    localized_titles:
+      en: Die Natali
+      nl: Die Natali
+    year: 1960
+    category: orchestral
+    catalogue:
+      opus: Op. 37
+    aliases:
+      - Die Natali
+      - Die Natali, Chorale Preludes for Christmas
+      - Chorale Preludes for Christmas
+      - Op. 37
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op44
+    composer_id: samuel-barber
+    canonical_title: A Fadograph of a Yestern Scene
+    localized_titles:
+      en: A Fadograph of a Yestern Scene
+      nl: A Fadograph of a Yestern Scene
+    year: 1971
+    category: orchestral
+    catalogue:
+      opus: Op. 44
+    aliases:
+      - A Fadograph of a Yestern Scene
+      - Fadograph of a Yestern Scene
+      - Op. 44
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op47
+    composer_id: samuel-barber
+    canonical_title: Third Essay for Orchestra
+    localized_titles:
+      en: Third Essay for Orchestra
+      nl: Third Essay for Orchestra
+    year: 1978
+    category: orchestral
+    catalogue:
+      opus: Op. 47
+    aliases:
+      - Third Essay for Orchestra
+      - Essay for Orchestra No. 3
+      - Op. 47
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-commando-march
+    composer_id: samuel-barber
+    canonical_title: Commando March
+    localized_titles:
+      en: Commando March
+      nl: Commando March
+    year: 1943
+    category: concert-band
+    aliases:
+      - Commando March
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-funeral-march
+    composer_id: samuel-barber
+    canonical_title: Funeral March
+    localized_titles:
+      en: Funeral March
+      nl: Treurmars
+    year: 1943
+    category: concert-band
+    aliases:
+      - Funeral March
+      - Treurmars
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op14
+    composer_id: samuel-barber
+    canonical_title: Violin Concerto
+    localized_titles:
+      en: Violin Concerto
+      nl: Vioolconcert
+    year: 1939-1940
+    category: concertante
+    catalogue:
+      opus: Op. 14
+    aliases:
+      - Violin Concerto
+      - Violin Concerto, Op. 14
+      - Vioolconcert
+      - Op. 14
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op21
+    composer_id: samuel-barber
+    canonical_title: Capricorn Concerto
+    localized_titles:
+      en: Capricorn Concerto
+      nl: Capricorn Concerto
+    year: 1944
+    category: concertante
+    catalogue:
+      opus: Op. 21
+    aliases:
+      - Capricorn Concerto
+      - Capricorn Concerto, Op. 21
+      - Op. 21
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op22
+    composer_id: samuel-barber
+    canonical_title: Cello Concerto
+    localized_titles:
+      en: Cello Concerto
+      nl: Celloconcert
+    year: 1945
+    category: concertante
+    catalogue:
+      opus: Op. 22
+    aliases:
+      - Cello Concerto
+      - Cello Concerto, Op. 22
+      - Celloconcert
+      - Op. 22
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op36
+    composer_id: samuel-barber
+    canonical_title: Toccata Festiva
+    localized_titles:
+      en: Toccata Festiva
+      nl: Toccata Festiva
+    year: 1960
+    category: concertante
+    catalogue:
+      opus: Op. 36
+    aliases:
+      - Toccata Festiva
+      - Toccata Festiva, Op. 36
+      - Op. 36
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op38
+    composer_id: samuel-barber
+    canonical_title: Piano Concerto
+    localized_titles:
+      en: Piano Concerto
+      nl: Pianoconcert
+    year: 1961-1962
+    category: concertante
+    catalogue:
+      opus: Op. 38
+    aliases:
+      - Piano Concerto
+      - Piano Concerto, Op. 38
+      - Pianoconcert
+      - Op. 38
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op48
+    composer_id: samuel-barber
+    canonical_title: Oboe Concerto
+    localized_titles:
+      en: Oboe Concerto
+      nl: Hoboconcert
+    year: 1977-1978
+    category: concertante
+    catalogue:
+      opus: Op. 48
+    aliases:
+      - Oboe Concerto
+      - Oboe Concerto, Op. 48
+      - Hoboconcert
+      - Op. 48
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-gypsy-dance-from-the-rose-tree
+    composer_id: samuel-barber
+    canonical_title: Gypsy Dance from The Rose Tree
+    localized_titles:
+      en: Gypsy Dance from The Rose Tree
+      nl: Gypsy Dance from The Rose Tree
+    year: 1922
+    category: chamber
+    aliases:
+      - Gypsy Dance from The Rose Tree
+      - Gypsy Dance
+      - The Rose Tree
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op1-chamber
+    composer_id: samuel-barber
+    canonical_title: Serenade
+    localized_titles:
+      en: Serenade
+      nl: Serenade
+    year: 1928
+    category: chamber
+    catalogue:
+      opus: Op. 1
+    aliases:
+      - Serenade
+      - Serenade, Op. 1
+      - Op. 1
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+    notes: >-
+      Chamber-music Serenade, modelled separately from the string-orchestra version.
+
+  - id: barber-op4
+    composer_id: samuel-barber
+    canonical_title: Violin Sonata
+    localized_titles:
+      en: Violin Sonata
+      nl: Vioolsonate
+    year: 1928
+    category: chamber
+    catalogue:
+      opus: Op. 4
+    aliases:
+      - Violin Sonata
+      - Violin Sonata, Op. 4
+      - Vioolsonate
+      - Op. 4
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op6
+    composer_id: samuel-barber
+    canonical_title: Cello Sonata
+    localized_titles:
+      en: Cello Sonata
+      nl: Cellosonate
+    year: 1932
+    category: chamber
+    catalogue:
+      opus: Op. 6
+    aliases:
+      - Cello Sonata
+      - Cello Sonata, Op. 6
+      - Cellosonate
+      - Op. 6
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op11
+    composer_id: samuel-barber
+    canonical_title: String Quartet
+    localized_titles:
+      en: String Quartet
+      nl: Strijkkwartet
+    year: 1936
+    category: chamber
+    catalogue:
+      opus: Op. 11
+    aliases:
+      - String Quartet
+      - String Quartet, Op. 11
+      - Strijkkwartet
+      - Op. 11
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-commemorative-march
+    composer_id: samuel-barber
+    canonical_title: Commemorative March
+    localized_titles:
+      en: Commemorative March
+      nl: Commemorative March
+    year: 1941
+    category: chamber
+    aliases:
+      - Commemorative March
+      - Commemorative March for violin, cello and piano
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-string-quartet-1947
+    composer_id: samuel-barber
+    canonical_title: String Quartet
+    localized_titles:
+      en: String Quartet
+      nl: Strijkkwartet
+    year: 1947
+    category: chamber
+    aliases:
+      - String Quartet
+      - String Quartet, 1947
+      - Strijkkwartet
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-adventure
+    composer_id: samuel-barber
+    canonical_title: Adventure
+    localized_titles:
+      en: Adventure
+      nl: Adventure
+    year: 1954
+    category: chamber
+    aliases:
+      - Adventure
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op31
+    composer_id: samuel-barber
+    canonical_title: Summer Music for Wind Quintet
+    localized_titles:
+      en: Summer Music for Wind Quintet
+      nl: Summer Music for Wind Quintet
+    year: 1956
+    category: chamber
+    catalogue:
+      opus: Op. 31
+    aliases:
+      - Summer Music for Wind Quintet
+      - Summer Music
+      - Summer Music, Op. 31
+      - Op. 31
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-chorale-for-washington-cathedral
+    composer_id: samuel-barber
+    canonical_title: Chorale for Washington Cathedral
+    localized_titles:
+      en: Chorale for Washington Cathedral
+      nl: Chorale for Washington Cathedral
+    year: 1960s
+    category: chamber
+    aliases:
+      - Chorale for Washington Cathedral
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op38a
+    composer_id: samuel-barber
+    canonical_title: Canzone
+    localized_titles:
+      en: Canzone
+      nl: Canzone
+    year: 1961
+    category: chamber
+    catalogue:
+      opus: Op. 38a
+    aliases:
+      - Canzone
+      - Canzone, Op. 38a
+      - Canzone for flute or violin and piano
+      - Op. 38a
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-mutations-from-bach
+    composer_id: samuel-barber
+    canonical_title: Mutations from Bach
+    localized_titles:
+      en: Mutations from Bach
+      nl: Mutations from Bach
+    year: 1967
+    category: chamber
+    aliases:
+      - Mutations from Bach
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-suite-for-carillon
+    composer_id: samuel-barber
+    canonical_title: Suite for carillon
+    localized_titles:
+      en: Suite for carillon
+      nl: Suite for carillon
+    year: 1931
+    category: carillon
+    aliases:
+      - Suite for carillon
+      - Suite for Carillon
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-melody-in-f
+    composer_id: samuel-barber
+    canonical_title: Melody in F
+    localized_titles:
+      en: Melody in F
+      nl: Melody in F
+    year: 1917
+    category: piano
+    aliases:
+      - Melody in F
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-sadness
+    composer_id: samuel-barber
+    canonical_title: Sadness
+    localized_titles:
+      en: Sadness
+      nl: Sadness
+    year: 1917
+    category: piano
+    aliases:
+      - Sadness
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-largo
+    composer_id: samuel-barber
+    canonical_title: Largo
+    localized_titles:
+      en: Largo
+      nl: Largo
+    year: 1918
+    category: piano
+    aliases:
+      - Largo
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-war-song
+    composer_id: samuel-barber
+    canonical_title: War Song
+    localized_titles:
+      en: War Song
+      nl: War Song
+    year: 1918
+    category: piano
+    aliases:
+      - War Song
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-at-twilight
+    composer_id: samuel-barber
+    canonical_title: At Twilight
+    localized_titles:
+      en: At Twilight
+      nl: At Twilight
+    year: 1919
+    category: piano
+    aliases:
+      - At Twilight
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-lullaby
+    composer_id: samuel-barber
+    canonical_title: Lullaby
+    localized_titles:
+      en: Lullaby
+      nl: Lullaby
+    year: 1919
+    category: piano
+    aliases:
+      - Lullaby
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-three-sketches
+    composer_id: samuel-barber
+    canonical_title: Three Sketches
+    localized_titles:
+      en: Three Sketches
+      nl: Three Sketches
+    year: 1923-1924
+    category: piano
+    aliases:
+      - Three Sketches
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-fantasie-haydn-style
+    composer_id: samuel-barber
+    canonical_title: Fantasie
+    localized_titles:
+      en: Fantasie
+      nl: Fantasie
+    year: 1924
+    category: piano
+    aliases:
+      - Fantasie
+      - Fantasie in the style of Joseph Haydn
+      - Fantasie for two pianos
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-prelude-to-a-tragic-drama
+    composer_id: samuel-barber
+    canonical_title: Prelude to a Tragic Drama
+    localized_titles:
+      en: Prelude to a Tragic Drama
+      nl: Prelude to a Tragic Drama
+    year: 1925
+    category: piano
+    aliases:
+      - Prelude to a Tragic Drama
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-fresh-from-west-chester
+    composer_id: samuel-barber
+    canonical_title: Fresh from West Chester
+    localized_titles:
+      en: Fresh from West Chester
+      nl: Fresh from West Chester
+    year: 1925-1926
+    category: piano
+    aliases:
+      - Fresh from West Chester
+      - Some Jazzing
+      - Fresh from West Chester (Some Jazzing)
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-essay-iii
+    composer_id: samuel-barber
+    canonical_title: Essay III
+    localized_titles:
+      en: Essay III
+      nl: Essay III
+    year: 1926
+    category: piano
+    aliases:
+      - Essay III
+      - Essay 3
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-interlude-no1
+    composer_id: samuel-barber
+    canonical_title: Interlude No. 1
+    localized_titles:
+      en: Interlude No. 1
+      nl: Interlude No. 1
+    year: 1931
+    category: piano
+    aliases:
+      - Interlude No. 1
+      - Adagio for Jeanne
+      - Interlude No. 1 (Adagio for Jeanne)
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-interlude-no2
+    composer_id: samuel-barber
+    canonical_title: Interlude No. 2
+    localized_titles:
+      en: Interlude No. 2
+      nl: Interlude No. 2
+    year: 1932
+    category: piano
+    aliases:
+      - Interlude No. 2
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op20
+    composer_id: samuel-barber
+    canonical_title: Excursions
+    localized_titles:
+      en: Excursions
+      nl: Excursions
+    year: 1944
+    category: piano
+    catalogue:
+      opus: Op. 20
+    aliases:
+      - Excursions
+      - Excursions, Op. 20
+      - Op. 20
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op26
+    composer_id: samuel-barber
+    canonical_title: Piano Sonata
+    localized_titles:
+      en: Piano Sonata
+      nl: Pianosonate
+    year: 1948
+    category: piano
+    catalogue:
+      opus: Op. 26
+    aliases:
+      - Piano Sonata
+      - Piano Sonata, Op. 26
+      - Pianosonate
+      - Op. 26
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op28-piano-four-hands
+    composer_id: samuel-barber
+    canonical_title: Souvenirs, Suite
+    localized_titles:
+      en: Souvenirs, Suite
+      nl: Souvenirs, suite
+    year: 1952
+    category: piano
+    catalogue:
+      opus: Op. 28
+    aliases:
+      - Souvenirs, Suite
+      - Souvenirs Suite
+      - Souvenirs for piano four hands
+      - Souvenirs, Suite, pf-4h
+      - Op. 28
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op28-piano-suite
+    composer_id: samuel-barber
+    canonical_title: Souvenirs, Suite
+    localized_titles:
+      en: Souvenirs, Suite
+      nl: Souvenirs, suite
+    year: 1954
+    category: piano
+    catalogue:
+      opus: Op. 28
+    aliases:
+      - Souvenirs, Suite
+      - Souvenirs Suite
+      - Souvenirs, Op. 28
+      - Op. 28
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op33
+    composer_id: samuel-barber
+    canonical_title: Nocturne
+    localized_titles:
+      en: Nocturne
+      nl: Nocturne
+    year: 1959
+    category: piano
+    catalogue:
+      opus: Op. 33
+    aliases:
+      - Nocturne
+      - Nocturne, Op. 33
+      - Homage to John Field
+      - Nocturne (Homage to John Field)
+      - Op. 33
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-after-the-concert
+    composer_id: samuel-barber
+    canonical_title: After the Concert
+    localized_titles:
+      en: After the Concert
+      nl: After the Concert
+    year: 1960s
+    category: piano
+    aliases:
+      - After the Concert
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op46
+    composer_id: samuel-barber
+    canonical_title: Ballade
+    localized_titles:
+      en: Ballade
+      nl: Ballade
+    year: 1977
+    category: piano
+    catalogue:
+      opus: Op. 46
+    aliases:
+      - Ballade
+      - Ballade, Op. 46
+      - Op. 46
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: barber-op24
+    composer_id: samuel-barber
+    canonical_title: 'Knoxville: Summer of 1915'
+    localized_titles:
+      en: 'Knoxville: Summer of 1915'
+      nl: 'Knoxville: Summer of 1915'
+    year: 1947
+    category: vocal
+    catalogue:
+      opus: Op. 24
+    aliases:
+      - 'Knoxville: Summer of 1915'
+      - Knoxville Summer of 1915
+      - Knoxville, Summer of 1915
+      - Op. 24
+    authorities:
+      musicbrainz_work_id:
+      wikidata:

--- a/data/works/valentyn-silvestrov/works.yaml
+++ b/data/works/valentyn-silvestrov/works.yaml
@@ -1,0 +1,588 @@
+composer_id: valentyn-silvestrov
+source_note: >-
+  Data-first pilot for a composer not yet represented by a markdown page in the collection.
+  Work selection is based on commonly listed principal works and can be refined before
+  generating docs/silvestrov.md.
+works:
+  - id: silvestrov-symphony-1
+    composer_id: valentyn-silvestrov
+    canonical_title: Symphony No. 1
+    localized_titles:
+      en: Symphony No. 1
+      nl: Symfonie nr. 1
+    year: 1963, rev. 1974
+    category: orchestral
+    aliases:
+      - Symphony No. 1
+      - Symphony 1
+      - First Symphony
+      - Symfonie nr. 1
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-classical-overture
+    composer_id: valentyn-silvestrov
+    canonical_title: Classical Overture
+    localized_titles:
+      en: Classical Overture
+      nl: Classical Overture
+    year: 1964
+    category: orchestral
+    aliases:
+      - Classical Overture
+      - Klassieke ouverture
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-monodia
+    composer_id: valentyn-silvestrov
+    canonical_title: Monodia
+    localized_titles:
+      en: Monodia
+      nl: Monodia
+    year: 1965
+    category: orchestral
+    aliases:
+      - Monodia
+      - Monodia for piano and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-spectres
+    composer_id: valentyn-silvestrov
+    canonical_title: Spectres
+    localized_titles:
+      en: Spectres
+      nl: Spectres
+    year: 1965
+    category: chamber-orchestra
+    aliases:
+      - Spectres
+      - Spektra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-symphony-2
+    composer_id: valentyn-silvestrov
+    canonical_title: Symphony No. 2
+    localized_titles:
+      en: Symphony No. 2
+      nl: Symfonie nr. 2
+    year: 1965
+    category: chamber-orchestra
+    aliases:
+      - Symphony No. 2
+      - Symphony 2
+      - Second Symphony
+      - Symphony No. 2 for flute, timpani, piano, and string orchestra
+      - Symfonie nr. 2
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-symphony-3-eschatophony
+    composer_id: valentyn-silvestrov
+    canonical_title: Symphony No. 3, Eschatophony
+    localized_titles:
+      en: Symphony No. 3, Eschatophony
+      nl: Symfonie nr. 3, Eschatophony
+    year: 1966
+    category: orchestral
+    aliases:
+      - Symphony No. 3
+      - Symphony 3
+      - Third Symphony
+      - Eschatophony
+      - Eschatophonie
+      - Symphony No. 3, Eschatophony
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-hymn
+    composer_id: valentyn-silvestrov
+    canonical_title: Hymn
+    localized_titles:
+      en: Hymn
+      nl: Hymne
+    year: 1968
+    category: orchestral
+    aliases:
+      - Hymn
+      - Hymne
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-poem-liatoshynsky
+    composer_id: valentyn-silvestrov
+    canonical_title: Poem
+    localized_titles:
+      en: Poem
+      nl: Poem
+    year: 1968
+    category: orchestral
+    aliases:
+      - Poem
+      - Poem in memoriam B. N. Liatoshynsky
+      - Poem in memory of Borys Lyatoshynsky
+      - Poem in memoriam Liatoshynsky
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-meditation
+    composer_id: valentyn-silvestrov
+    canonical_title: Meditation
+    localized_titles:
+      en: Meditation
+      nl: Meditatie
+    year: 1972
+    category: orchestral
+    aliases:
+      - Meditation
+      - Meditation for chamber orchestra
+      - Meditatie
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-postludium-piano-orchestra
+    composer_id: valentyn-silvestrov
+    canonical_title: Postludium
+    localized_titles:
+      en: Postludium
+      nl: Postludium
+    year: 1974
+    category: orchestral
+    aliases:
+      - Postludium
+      - Postludium for piano and orchestra
+      - Postlude for piano and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-symphony-4
+    composer_id: valentyn-silvestrov
+    canonical_title: Symphony No. 4
+    localized_titles:
+      en: Symphony No. 4
+      nl: Symfonie nr. 4
+    year: 1976
+    category: orchestral
+    aliases:
+      - Symphony No. 4
+      - Symphony 4
+      - Fourth Symphony
+      - Symphony No. 4 for brass instruments and strings
+      - Symfonie nr. 4
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-serenade-chamber-orchestra
+    composer_id: valentyn-silvestrov
+    canonical_title: Serenade for Chamber Orchestra
+    localized_titles:
+      en: Serenade for Chamber Orchestra
+      nl: Serenade for kamerorkest
+    year: 1978
+    category: orchestral
+    aliases:
+      - Serenade for Chamber Orchestra
+      - Serenade
+      - Serenade for chamber orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-symphony-5
+    composer_id: valentyn-silvestrov
+    canonical_title: Symphony No. 5
+    localized_titles:
+      en: Symphony No. 5
+      nl: Symfonie nr. 5
+    year: 1980-1982
+    category: orchestral
+    aliases:
+      - Symphony No. 5
+      - Symphony 5
+      - Fifth Symphony
+      - Symfonie nr. 5
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-metamusik
+    composer_id: valentyn-silvestrov
+    canonical_title: Metamusik
+    localized_titles:
+      en: Metamusik
+      de: Metamusik
+      nl: Metamusik
+    year: 1992
+    category: orchestral
+    aliases:
+      - Metamusik
+      - Metamusic
+      - Metamusik for piano and orchestra
+      - Metamusic for piano and orchestra
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-symphony-6
+    composer_id: valentyn-silvestrov
+    canonical_title: Symphony No. 6
+    localized_titles:
+      en: Symphony No. 6
+      nl: Symfonie nr. 6
+    year: 1994-1995
+    category: orchestral
+    aliases:
+      - Symphony No. 6
+      - Symphony 6
+      - Sixth Symphony
+      - Symfonie nr. 6
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-dedication-symphony
+    composer_id: valentyn-silvestrov
+    canonical_title: Dedication Symphony
+    localized_titles:
+      en: Dedication Symphony
+      nl: Dedication Symphony
+    year: 1990-1991
+    category: orchestral
+    aliases:
+      - Dedication Symphony
+      - Dedication
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-symphony-7
+    composer_id: valentyn-silvestrov
+    canonical_title: Symphony No. 7
+    localized_titles:
+      en: Symphony No. 7
+      nl: Symfonie nr. 7
+    year: 2002-2003
+    category: orchestral
+    aliases:
+      - Symphony No. 7
+      - Symphony 7
+      - Seventh Symphony
+      - Symfonie nr. 7
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-requiem-for-larissa
+    composer_id: valentyn-silvestrov
+    canonical_title: Requiem for Larissa
+    localized_titles:
+      en: Requiem for Larissa
+      nl: Requiem for Larissa
+    year: 1997-1999
+    category: vocal-and-choral
+    aliases:
+      - Requiem for Larissa
+      - Requiem für Larissa
+      - Requiem pour Larissa
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-silent-songs
+    composer_id: valentyn-silvestrov
+    canonical_title: Silent Songs
+    localized_titles:
+      en: Silent Songs
+      nl: Silent Songs
+    year: 1974-1977
+    category: vocal
+    aliases:
+      - Silent Songs
+      - Stille Lieder
+      - Quiet Songs
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-simple-songs
+    composer_id: valentyn-silvestrov
+    canonical_title: Simple Songs
+    localized_titles:
+      en: Simple Songs
+      nl: Simple Songs
+    category: vocal
+    aliases:
+      - Simple Songs
+      - Simple Songs cycle
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-stufen
+    composer_id: valentyn-silvestrov
+    canonical_title: Stufen
+    localized_titles:
+      de: Stufen
+      en: Steps
+      nl: Stufen
+    category: vocal
+    aliases:
+      - Stufen
+      - Steps
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-maidan-2014
+    composer_id: valentyn-silvestrov
+    canonical_title: Maidan-2014
+    localized_titles:
+      en: Maidan-2014
+      nl: Maidan-2014
+    year: 2014
+    category: vocal-and-choral
+    aliases:
+      - Maidan
+      - Maidan-2014
+      - Maidan 2014
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-prayer-for-ukraine
+    composer_id: valentyn-silvestrov
+    canonical_title: Prayer for Ukraine
+    localized_titles:
+      en: Prayer for Ukraine
+      uk: Молитва за Україну
+      nl: Gebed voor Oekraïne
+    year: 2014
+    category: choral
+    aliases:
+      - Prayer for Ukraine
+      - Gebed voor Oekraïne
+      - Gebet für die Ukraine
+      - Molytva za Ukrayinu
+      - Молитва за Україну
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-diptych
+    composer_id: valentyn-silvestrov
+    canonical_title: Diptych
+    localized_titles:
+      en: Diptych
+      nl: Diptiek
+    category: choral
+    aliases:
+      - Diptych
+      - Diptiek
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-string-quartet-1
+    composer_id: valentyn-silvestrov
+    canonical_title: String Quartet No. 1
+    localized_titles:
+      en: String Quartet No. 1
+      nl: Strijkkwartet nr. 1
+    year: 1974
+    category: chamber
+    aliases:
+      - String Quartet No. 1
+      - String Quartet 1
+      - First String Quartet
+      - Strijkkwartet nr. 1
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-string-quartet-2
+    composer_id: valentyn-silvestrov
+    canonical_title: String Quartet No. 2
+    localized_titles:
+      en: String Quartet No. 2
+      nl: Strijkkwartet nr. 2
+    year: 1988
+    category: chamber
+    aliases:
+      - String Quartet No. 2
+      - String Quartet 2
+      - Second String Quartet
+      - Strijkkwartet nr. 2
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-string-quartet-3
+    composer_id: valentyn-silvestrov
+    canonical_title: String Quartet No. 3
+    localized_titles:
+      en: String Quartet No. 3
+      nl: Strijkkwartet nr. 3
+    year: 2011
+    category: chamber
+    aliases:
+      - String Quartet No. 3
+      - String Quartet 3
+      - Third String Quartet
+      - Strijkkwartet nr. 3
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-piano-quintet
+    composer_id: valentyn-silvestrov
+    canonical_title: Piano Quintet
+    localized_titles:
+      en: Piano Quintet
+      nl: Pianokwintet
+    year: 1961
+    category: chamber
+    aliases:
+      - Piano Quintet
+      - Pianokwintet
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-post-scriptum
+    composer_id: valentyn-silvestrov
+    canonical_title: Post Scriptum
+    localized_titles:
+      en: Post Scriptum
+      nl: Post Scriptum
+    year: 1990
+    category: chamber
+    aliases:
+      - Post Scriptum
+      - Postscriptum
+      - Sonata for violin and piano
+      - Post Scriptum for violin and piano
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-melodies-of-the-moments
+    composer_id: valentyn-silvestrov
+    canonical_title: Melodies of the Moments
+    localized_titles:
+      en: Melodies of the Moments
+      nl: Melodies of the Moments
+    category: piano
+    aliases:
+      - Melodies of the Moments
+      - Melodien der Augenblicke
+      - Melodii momentov
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-bagatelles
+    composer_id: valentyn-silvestrov
+    canonical_title: Bagatelles
+    localized_titles:
+      en: Bagatelles
+      nl: Bagatelles
+    category: piano
+    aliases:
+      - Bagatelles
+      - Bagatellen
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-kitsch-music
+    composer_id: valentyn-silvestrov
+    canonical_title: Kitsch-Music
+    localized_titles:
+      en: Kitsch-Music
+      nl: Kitsch-Music
+    year: 1977
+    category: piano
+    aliases:
+      - Kitsch-Music
+      - Kitsch Music
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-piano-sonata-1
+    composer_id: valentyn-silvestrov
+    canonical_title: Piano Sonata No. 1
+    localized_titles:
+      en: Piano Sonata No. 1
+      nl: Pianosonate nr. 1
+    year: 1972
+    category: piano
+    aliases:
+      - Piano Sonata No. 1
+      - Piano Sonata 1
+      - First Piano Sonata
+      - Pianosonate nr. 1
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-piano-sonata-2
+    composer_id: valentyn-silvestrov
+    canonical_title: Piano Sonata No. 2
+    localized_titles:
+      en: Piano Sonata No. 2
+      nl: Pianosonate nr. 2
+    year: 1975
+    category: piano
+    aliases:
+      - Piano Sonata No. 2
+      - Piano Sonata 2
+      - Second Piano Sonata
+      - Pianosonate nr. 2
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-piano-sonata-3
+    composer_id: valentyn-silvestrov
+    canonical_title: Piano Sonata No. 3
+    localized_titles:
+      en: Piano Sonata No. 3
+      nl: Pianosonate nr. 3
+    year: 1979
+    category: piano
+    aliases:
+      - Piano Sonata No. 3
+      - Piano Sonata 3
+      - Third Piano Sonata
+      - Pianosonate nr. 3
+    authorities:
+      musicbrainz_work_id:
+      wikidata:
+
+  - id: silvestrov-naive-music
+    composer_id: valentyn-silvestrov
+    canonical_title: Naive Music
+    localized_titles:
+      en: Naive Music
+      nl: Naive Music
+    category: piano
+    aliases:
+      - Naive Music
+      - Naïve Music
+    authorities:
+      musicbrainz_work_id:
+      wikidata:

--- a/data/works/wolfgang-amadeus-mozart/works.yaml
+++ b/data/works/wolfgang-amadeus-mozart/works.yaml
@@ -1,0 +1,181 @@
+composer_id: wolfgang-amadeus-mozart
+source_note: >-
+  Representative pilot set based on the existing docs/mozart.md page. It tests K/KV
+  identifiers, opera title translations, nicknames, sacred works and concertos.
+works:
+  - id: mozart-k47d
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Missa brevis in G major
+    localized_titles: { en: Missa brevis in G major, de: Missa brevis G-Dur, nl: Missa brevis in G groot }
+    category: sacred-choral
+    catalogue: { k: K. 47d }
+    aliases: [Missa brevis in G, Missa brevis in G major, K. 47d, KV 47d]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k427
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Mass in C minor
+    localized_titles: { en: Mass in C minor, de: Messe c-Moll, nl: Mis in c klein }
+    category: sacred-choral
+    catalogue: { k: K. 427 }
+    aliases: [Great Mass, Große Messe c-Moll, Mass in C Minor, K. 427, KV 427]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k626
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Requiem in D minor
+    localized_titles: { en: Requiem in D minor, de: Requiem d-Moll, nl: Requiem in d klein }
+    category: sacred-choral
+    catalogue: { k: K. 626 }
+    aliases: [Requiem, Requiem Mass in D minor, Requiem in D minor, K. 626, KV 626]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k165-158a
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Exsultate, jubilate
+    localized_titles: { en: Exsultate, jubilate, nl: Exsultate, jubilate }
+    category: sacred-choral
+    catalogue: { k: K. 165/158a }
+    aliases: [Exsultate jubilate, Exsultate, jubilate, K. 165, K. 158a, KV 165]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k126
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Il sogno di Scipione
+    localized_titles: { it: Il sogno di Scipione, en: Scipio's Dream, nl: Il sogno di Scipione }
+    category: opera
+    catalogue: { k: K. 126 }
+    aliases: [Il sogno di Scipione, Scipio's Dream, K. 126, KV 126]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k135
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Lucio Silla
+    localized_titles: { it: Lucio Silla, en: Lucio Silla, nl: Lucio Silla }
+    category: opera
+    catalogue: { k: K. 135 }
+    aliases: [Lucio Silla, K. 135, KV 135]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k196
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: La finta giardiniera
+    localized_titles: { it: La finta giardiniera, en: The Pretend Garden-Girl, nl: La finta giardiniera }
+    category: opera
+    catalogue: { k: K. 196 }
+    aliases: [La finta giardiniera, The Pretend Garden-Girl, K. 196, KV 196]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k384
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Die Entführung aus dem Serail
+    localized_titles: { de: Die Entführung aus dem Serail, en: The Abduction from the Seraglio, nl: De ontvoering uit de harem }
+    category: opera
+    catalogue: { k: K. 384 }
+    aliases: [Die Entführung aus dem Serail, The Abduction from the Seraglio, Entführung, K. 384, KV 384]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k486
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Der Schauspieldirektor
+    localized_titles: { de: Der Schauspieldirektor, en: The Impresario, nl: Der Schauspieldirektor }
+    category: opera
+    catalogue: { k: K. 486 }
+    aliases: [Der Schauspieldirektor, The Impresario, K. 486, KV 486]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k527
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Don Giovanni
+    localized_titles: { it: Don Giovanni, en: Don Giovanni, nl: Don Giovanni }
+    category: opera
+    catalogue: { k: K. 527 }
+    aliases: [Don Giovanni, Il dissoluto punito, K. 527, KV 527]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k504
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Symphony No. 38 in D major, Prague
+    localized_titles: { en: Symphony No. 38 in D major, Prague, nl: Symfonie nr. 38 in D groot, Praag }
+    category: orchestral
+    catalogue: { k: K. 504 }
+    aliases: [Symphony No. 38, Prague Symphony, Praagse symfonie, K. 504, KV 504]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k543
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Symphony No. 39 in E-flat major
+    localized_titles: { en: Symphony No. 39 in E-flat major, nl: Symfonie nr. 39 in Es groot }
+    category: orchestral
+    catalogue: { k: K. 543 }
+    aliases: [Symphony No. 39, K. 543, KV 543]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k550
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Symphony No. 40 in G minor
+    localized_titles: { en: Symphony No. 40 in G minor, nl: Symfonie nr. 40 in g klein }
+    category: orchestral
+    catalogue: { k: K. 550 }
+    aliases: [Symphony No. 40, K. 550, KV 550]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k551
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Symphony No. 41 in C major, Jupiter
+    localized_titles: { en: Symphony No. 41 in C major, Jupiter, nl: Symfonie nr. 41 in C groot, Jupiter }
+    category: orchestral
+    catalogue: { k: K. 551 }
+    aliases: [Symphony No. 41, Jupiter Symphony, Jupiter, K. 551, KV 551]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k271
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Piano Concerto No. 9 in E-flat major, Jenamy
+    localized_titles: { en: Piano Concerto No. 9 in E-flat major, Jenamy, nl: Pianoconcert nr. 9 in Es groot, Jenamy }
+    category: piano-concerto
+    catalogue: { k: K. 271 }
+    aliases: [Piano Concerto No. 9, Jenamy, Jeunehomme, K. 271, KV 271]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k466
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Piano Concerto No. 20 in D minor
+    localized_titles: { en: Piano Concerto No. 20 in D minor, nl: Pianoconcert nr. 20 in d klein }
+    category: piano-concerto
+    catalogue: { k: K. 466 }
+    aliases: [Piano Concerto No. 20, K. 466, KV 466]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k467
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Piano Concerto No. 21 in C major
+    localized_titles: { en: Piano Concerto No. 21 in C major, nl: Pianoconcert nr. 21 in C groot }
+    category: piano-concerto
+    catalogue: { k: K. 467 }
+    aliases: [Piano Concerto No. 21, Elvira Madigan, K. 467, KV 467]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k488
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Piano Concerto No. 23 in A major
+    localized_titles: { en: Piano Concerto No. 23 in A major, nl: Pianoconcert nr. 23 in A groot }
+    category: piano-concerto
+    catalogue: { k: K. 488 }
+    aliases: [Piano Concerto No. 23, K. 488, KV 488]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k491
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Piano Concerto No. 24 in C minor
+    localized_titles: { en: Piano Concerto No. 24 in C minor, nl: Pianoconcert nr. 24 in c klein }
+    category: piano-concerto
+    catalogue: { k: K. 491 }
+    aliases: [Piano Concerto No. 24, K. 491, KV 491]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k622
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Clarinet Concerto in A major
+    localized_titles: { en: Clarinet Concerto in A major, nl: Klarinetconcert in A groot }
+    category: woodwind-concerto
+    catalogue: { k: K. 622 }
+    aliases: [Clarinet Concerto, Klarinettenkonzert, K. 622, KV 622]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k361
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Serenade No. 10 in B-flat major, Gran Partita
+    localized_titles: { en: Serenade No. 10 in B-flat major, Gran Partita, nl: Gran Partita }
+    category: serenades
+    catalogue: { k: K. 361 }
+    aliases: [Gran Partita, Serenade No. 10, K. 361, KV 361]
+    authorities: { musicbrainz_work_id:, wikidata: }
+  - id: mozart-k525
+    composer_id: wolfgang-amadeus-mozart
+    canonical_title: Serenade No. 13 in G major, Eine kleine Nachtmusik
+    localized_titles: { de: Eine kleine Nachtmusik, en: Eine kleine Nachtmusik, nl: Eine kleine Nachtmusik }
+    category: serenades
+    catalogue: { k: K. 525 }
+    aliases: [Eine kleine Nachtmusik, Serenade No. 13, K. 525, KV 525]
+    authorities: { musicbrainz_work_id:, wikidata: }


### PR DESCRIPTION
## Summary

Implements the first pilot for issue #59 by introducing canonical work identity records across a deliberately varied set of composers.

This PR adds:

- `data/works/README.md` with the proposed work data format.
- Berlioz records using one-file-per-work, to test fine-grained storage.
- Composer-level `works.yaml` files for Adams, Barber, Silvestrov, J.S. Bach, C.P.E. Bach, Beethoven, Mozart, Bartók, and Berio.
- Support in the data format for aliases, translated/localized titles, catalogue numbers where available, language-independent internal IDs, and optional external authority IDs.

## Pilot coverage

The pilot now covers several distinct modelling situations:

- existing composer page with moderate scope: Berlioz;
- existing composer pages with larger or more varied lists: Adams, Barber, J.S. Bach, Beethoven, Mozart, Berio;
- composers not yet represented by markdown pages: Silvestrov, C.P.E. Bach, Bartók;
- catalogue systems: opus, BWV, Wq/H, K/KV, Sz/BB, WoO/Hess;
- modern works without catalogue numbers: Adams, Silvestrov, Berio;
- translated titles and nicknames: Eroica, Moonlight, Jupiter, Bluebeard's Castle, Gran Partita;
- derived or related works: Bach arrangements, Beethoven Op. 61a, Berio Sequenza/Chemins, Barber versions, Bartók versions.

## Scope of the pilot

The pilot intentionally does not modify the existing composer pages or site rendering. It only adds structured work identity data. This keeps the change reviewable and allows the model to be validated before applying it to the rest of the collection.

For very large composers, the added files are representative pilot sets rather than full catalogue migrations. This is deliberate: the purpose is to validate the schema and the future agent workflow before generating or importing thousands of work records.

## MusicBrainz authority evaluation

The format includes a nullable `authorities.musicbrainz_work_id` field. MusicBrainz appears suitable as an optional work authority because it distinguishes works from recordings and releases, but the local repository ID remains the primary stable identifier. For this pilot, MusicBrainz IDs are left empty unless individually verified later.

## Acceptance criteria

Closes #59

- [x] A proposed work data format is documented.
- [x] A small pilot set of works is added.
- [x] The format supports aliases and translated titles.
- [x] The format supports language-independent internal identities and localized display titles.
- [x] The format supports works even when the composer page or complete works list is incomplete.
- [x] A future validation script can match input metadata against these aliases.
- [x] The feasibility of using MusicBrainz work identifiers as an authority source has been evaluated.

## Notes for review

Please review especially:

- whether `canonical_title` plus `localized_titles` is the right balance, or whether `canonical` should be fully language-keyed;
- whether one file per work or one file per composer is preferable for the full collection;
- whether large composers should be fully hand-curated, generated from markdown, imported from authority data, or treated incrementally;
- whether adapted, extracted, or related works should be represented as separate work records, aliases, or explicit relationships in a later schema version.
