### PR TITLE
Introduce canonical artist identities pilot

### DIFF
--- a/data/artists/README.md
+++ b/data/artists/README.md
@@ -1,0 +1,140 @@
+# Canonical artist data
+
+This directory contains canonical identities for people, ensembles, orchestras, choirs,
+and other credited musical entities. The purpose is to prevent spelling, language,
+transliteration, abbreviation, and script differences from creating duplicate artists.
+
+## Location
+
+Artist records may be stored in composer- or migration-sized YAML files under:
+
+```text
+data/artists/
+```
+
+Each record must have a globally unique, stable `id`.
+
+## Proposed format
+
+```yaml
+id: royal-concertgebouw-orchestra
+type: orchestra
+canonical_name: Royal Concertgebouw Orchestra
+display_names:
+  en: Royal Concertgebouw Orchestra
+  nl: Koninklijk Concertgebouworkest
+aliases:
+  - Concertgebouw Orchestra
+  - RCO
+country: Netherlands
+city: Amsterdam
+authorities:
+  musicbrainz_artist_id:
+  wikidata:
+```
+
+For a person:
+
+```yaml
+id: dmitri-shostakovich
+type: composer
+canonical_name: Dmitri Shostakovich
+display_names:
+  en: Dmitri Shostakovich
+  nl: Dmitri Sjostakovitsj
+  de: Dmitri Schostakowitsch
+  ru: Дмитрий Шостакович
+aliases:
+  - Dmitry Shostakovich
+  - Shostakovich
+  - Sjostakovitsj
+authorities:
+  musicbrainz_artist_id:
+  wikidata:
+```
+
+## Required fields
+
+- `id`: stable internal identity, independent of display language.
+- `type`: the primary artist type.
+- `canonical_name`: default display name when no localized name is selected.
+
+## Recommended fields
+
+- `display_names`: language- or script-specific preferred names.
+- `aliases`: abbreviations, shortened forms, transliterations, historical forms, and metadata variants.
+- `country`: country associated with an organization or person when useful.
+- `city`: home city for an ensemble or institution when useful.
+- `instruments`: instruments for soloists or instrumentalists.
+- `voice`: voice type for singers.
+- `authorities`: verified external identifiers.
+- `notes`: local modelling notes.
+
+## Artist types
+
+The initial controlled vocabulary is:
+
+```text
+composer
+conductor
+singer
+instrumentalist
+soloist
+orchestra
+ensemble
+choir
+institution
+label
+```
+
+`soloist` should be used only when a more specific role is not known. A person may later
+need multiple roles; a future schema can add `roles` while retaining `type` as the primary
+classification.
+
+## Identifier conventions
+
+Use a stable, lowercase, ASCII identifier. The ID should normally resemble the best-known
+international name, but it is an internal key and must not change merely because the public
+display name changes.
+
+Examples:
+
+```text
+royal-concertgebouw-orchestra
+bernard-haitink
+dmitri-shostakovich
+akademie-fuer-alte-musik-berlin
+```
+
+## Matching rule for future validation
+
+A future validation script should normalize and compare:
+
+1. `id`
+2. `canonical_name`
+3. all values in `display_names`
+4. all values in `aliases`
+
+Normalization should include:
+
+- case folding;
+- Unicode normalization;
+- punctuation removal;
+- repeated-whitespace normalization;
+- optional accent/diacritic folding;
+- common abbreviation normalization;
+- transliteration-aware comparison where practical.
+
+The validator should warn rather than automatically merge when a new name closely resembles
+an existing identity. Short aliases such as surnames and initials can be ambiguous.
+
+## External authority evaluation
+
+MusicBrainz artist identifiers are suitable as optional authority identifiers because they
+cover both people and groups and maintain aliases and relationships. They should not replace
+local IDs: external records can be merged, split, renamed, or temporarily unavailable.
+
+The repository should store only verified authority IDs plus local additions. Empty authority
+fields are preferable to guessed IDs. MusicBrainz aliases may assist reconciliation, but local
+aliases remain necessary for Dutch spellings, collection-specific abbreviations, and metadata
+variants encountered in streaming services.

--- a/data/artists/pilot.yaml
+++ b/data/artists/pilot.yaml
@@ -1,0 +1,207 @@
+artists:
+  - id: royal-concertgebouw-orchestra
+    type: orchestra
+    canonical_name: Royal Concertgebouw Orchestra
+    display_names:
+      en: Royal Concertgebouw Orchestra
+      nl: Koninklijk Concertgebouworkest
+    aliases:
+      - Concertgebouw Orchestra
+      - Royal Concertgebouw Orch.
+      - Koninklijk Concertgebouw Orkest
+      - Concertgebouworkest
+      - RCO
+    country: Netherlands
+    city: Amsterdam
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: bernard-haitink
+    type: conductor
+    canonical_name: Bernard Haitink
+    display_names:
+      en: Bernard Haitink
+      nl: Bernard Haitink
+    aliases:
+      - B. Haitink
+      - Haitink
+      - Bernard Johan Herman Haitink
+    country: Netherlands
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: dmitri-shostakovich
+    type: composer
+    canonical_name: Dmitri Shostakovich
+    display_names:
+      en: Dmitri Shostakovich
+      nl: Dmitri Sjostakovitsj
+      de: Dmitri Schostakowitsch
+      ru: Дмитрий Шостакович
+    aliases:
+      - Dmitry Shostakovich
+      - Dmitri Dmitriyevich Shostakovich
+      - Dmitri Sjostakovitsj
+      - Dmitri Schostakowitsch
+      - Shostakovich
+      - Sjostakovitsj
+      - Шостакович
+      - Дмитрий Дмитриевич Шостакович
+    country: Russia
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: akademie-fuer-alte-musik-berlin
+    type: ensemble
+    canonical_name: Akademie für Alte Musik Berlin
+    display_names:
+      de: Akademie für Alte Musik Berlin
+      en: Academy for Early Music Berlin
+      nl: Akademie für Alte Musik Berlin
+    aliases:
+      - Akademie fuer Alte Musik Berlin
+      - Academy for Ancient Music Berlin
+      - Academy for Early Music Berlin
+      - Akamus
+      - AKAMUS
+    country: Germany
+    city: Berlin
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: collegium-vocale-gent
+    type: choir
+    canonical_name: Collegium Vocale Gent
+    display_names:
+      nl: Collegium Vocale Gent
+      en: Collegium Vocale Ghent
+    aliases:
+      - Collegium Vocale Ghent
+      - Collegium Vocale
+      - CVG
+    country: Belgium
+    city: Ghent
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: bach-collegium-japan
+    type: ensemble
+    canonical_name: Bach Collegium Japan
+    display_names:
+      en: Bach Collegium Japan
+      ja: バッハ・コレギウム・ジャパン
+      nl: Bach Collegium Japan
+    aliases:
+      - BCJ
+      - Bach Collegium of Japan
+      - バッハ・コレギウム・ジャパン
+    country: Japan
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: chiaroscuro-quartet
+    type: ensemble
+    canonical_name: Chiaroscuro Quartet
+    display_names:
+      en: Chiaroscuro Quartet
+      nl: Chiaroscuro Quartet
+    aliases:
+      - Chiaroscuro Quartett
+      - Chiaroscuro String Quartet
+      - The Chiaroscuro Quartet
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: cathy-berberian
+    type: singer
+    canonical_name: Cathy Berberian
+    display_names:
+      en: Cathy Berberian
+      it: Cathy Berberian
+      nl: Cathy Berberian
+    aliases:
+      - Catherine Anahid Berberian
+      - C. Berberian
+      - Berberian
+    voice: mezzo-soprano
+    country: United States
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: simone-dinnerstein
+    type: instrumentalist
+    canonical_name: Simone Dinnerstein
+    display_names:
+      en: Simone Dinnerstein
+      nl: Simone Dinnerstein
+    aliases:
+      - S. Dinnerstein
+      - Dinnerstein
+    instruments:
+      - piano
+    country: United States
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: gidon-kremer
+    type: instrumentalist
+    canonical_name: Gidon Kremer
+    display_names:
+      en: Gidon Kremer
+      de: Gidon Kremer
+      lv: Gidons Krēmers
+      ru: Гидон Кремер
+      nl: Gidon Kremer
+    aliases:
+      - Gidons Kremers
+      - Gidon Kremers
+      - G. Kremer
+      - Kremer
+      - Гидон Кремер
+    instruments:
+      - violin
+    country: Latvia
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: san-francisco-symphony
+    type: orchestra
+    canonical_name: San Francisco Symphony
+    display_names:
+      en: San Francisco Symphony
+      nl: San Francisco Symphony
+    aliases:
+      - San Francisco Symphony Orchestra
+      - SFS
+      - SFSO
+    country: United States
+    city: San Francisco
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:
+
+  - id: john-eliot-gardiner
+    type: conductor
+    canonical_name: John Eliot Gardiner
+    display_names:
+      en: John Eliot Gardiner
+      nl: John Eliot Gardiner
+    aliases:
+      - Sir John Eliot Gardiner
+      - J. E. Gardiner
+      - John E. Gardiner
+      - Gardiner
+    country: United Kingdom
+    authorities:
+      musicbrainz_artist_id:
+      wikidata:


### PR DESCRIPTION
## Summary

Implements issue #60 as a lightweight canonical artist identity pilot.

This PR adds:

- `data/artists/README.md` documenting the proposed artist data format;
- `data/artists/pilot.yaml` with twelve representative canonical artist records;
- support for persons, orchestras, ensembles, choirs, singers, instrumentalists, conductors, and composers;
- localized display names, aliases, abbreviations, transliterations, and original-script forms;
- nullable MusicBrainz and Wikidata authority fields;
- proposed matching and warning rules for a future validation script.

## Pilot coverage

The pilot includes examples such as:

- Royal Concertgebouw Orchestra / Koninklijk Concertgebouworkest / RCO;
- Dmitri Shostakovich / Dmitri Sjostakovitsj / Dmitri Schostakowitsch / Дмитрий Шостакович;
- Akademie für Alte Musik Berlin / Akademie fuer Alte Musik Berlin / Akamus;
- individual conductors, singers, pianists, violinists, orchestras, ensembles, and choirs.

## Authority evaluation

MusicBrainz artist identifiers are treated as optional external authority identifiers, not as replacements for local stable IDs. Authority fields are left empty unless individually verified. This avoids guessed identifiers while keeping the schema ready for later reconciliation.

## Acceptance criteria

Closes #60
Part of #58

- [x] A proposed artist data format is documented.
- [x] A small pilot set of artists is added.
- [x] The format supports ensembles, orchestras, choirs, and individual performers.
- [x] The format supports aliases, abbreviations, transliterations, and original-script names.
- [x] The format supports language-independent internal identities and localized display names.
- [x] A future validation script can warn when a new artist resembles an existing canonical artist.
- [x] The feasibility of using MusicBrainz artist identifiers as an authority source has been evaluated.

## Notes for review

Please review especially:

- whether `type` should remain a single primary classification or become a `roles` list;
- whether pilot records should remain grouped in one YAML file or move to one file per artist;
- whether country values should later use ISO codes rather than display strings;
- how aggressively a future validator should treat surname-only and acronym aliases.
