### PR TITLE
Introduce canonical recording model pilot

### DIFF
--- a/data/recordings/README.md
+++ b/data/recordings/README.md
@@ -1,0 +1,181 @@
+# Canonical recording data
+
+This directory contains internal recording records. A recording represents a specific release or recorded performance and is separate from the public composer and work pages.
+
+The model supports:
+
+- multiple works on one recording;
+- references to canonical work IDs;
+- references to canonical artist IDs;
+- recommendation status per work;
+- unstable streaming links with status and last-checked metadata;
+- previous candidates that remain available internally without becoming public recommendations.
+
+## Location
+
+```text
+data/recordings/<recording_id>.yaml
+```
+
+For example:
+
+```text
+data/recordings/haitink-rco-berlioz-fantastique.yaml
+```
+
+## Required fields
+
+```yaml
+id: haitink-rco-berlioz-fantastique
+artists:
+  conductor:
+    - bernard-haitink
+  orchestra:
+    - royal-concertgebouw-orchestra
+works:
+  - work_id: berlioz-op14
+    status: recommended
+```
+
+- `id` is the repository's stable internal recording identifier.
+- `artists` maps performance roles to canonical artist IDs from `data/artists/`.
+- `works` lists canonical work IDs from `data/works/` and gives each work a recommendation status.
+
+## Recommended fields
+
+```yaml
+title: Berlioz: Symphonie fantastique
+label: Philips
+catalog_number: 0000 000
+year: 1979
+release_year: 1980
+
+artists:
+  conductor:
+    - bernard-haitink
+  orchestra:
+    - royal-concertgebouw-orchestra
+  soloist: []
+
+works:
+  - work_id: berlioz-op14
+    status: recommended
+    notes:
+
+links:
+  tidal:
+    status: active
+    url: https://tidal.com/browse/album/...
+    last_checked: 2026-07-10
+
+identifiers:
+  musicbrainz_release_id:
+  discogs_release_id:
+
+notes: >-
+  Optional local notes about edition, source, remastering, or selection decisions.
+```
+
+## Work statuses
+
+Each work on a recording has one of these statuses:
+
+- `recommended`: the current public recommendation for that work;
+- `candidate`: under consideration but not yet the public recommendation;
+- `previous_candidate`: previously considered and retained for history;
+- `superseded`: once recommended, but replaced by another recording;
+- `unavailable`: no longer usable as a recommendation, for example because the recording or link is unavailable.
+
+A recording can therefore contain one recommended work and another work that is only a candidate.
+
+The renderer must publish only work-recording combinations whose status is `recommended`. The presence of a recording in this directory does not itself make it public.
+
+## Streaming links
+
+Streaming links are external and unstable. Each service link should include:
+
+```yaml
+links:
+  tidal:
+    status: active
+    url: https://tidal.com/...
+    last_checked: 2026-07-10
+```
+
+Supported link statuses should initially be:
+
+- `active`
+- `unverified`
+- `unavailable`
+- `redirected`
+
+`last_checked` uses ISO date format (`YYYY-MM-DD`). A future validator can warn when an active link has not been checked within a configured period.
+
+A recording may include links for multiple services later without changing the work or artist references:
+
+```yaml
+links:
+  tidal: ...
+  spotify: ...
+  apple_music: ...
+```
+
+## Artist roles
+
+Artist roles are represented as lists, even where only one artist is expected:
+
+```yaml
+artists:
+  conductor:
+    - bernard-haitink
+  orchestra:
+    - royal-concertgebouw-orchestra
+  choir:
+    - bach-collegium-japan-chorus
+  soloist:
+    - mitsuko-uchida
+```
+
+This supports recordings with multiple conductors, ensembles, soloists, singers, or choirs. More specific roles such as `piano`, `violin`, `soprano`, or `narrator` may be added when useful, but should still contain canonical artist IDs.
+
+## Recording identity
+
+A recording ID should be stable and descriptive, but must not be treated as display text. A practical pattern is:
+
+```text
+<lead-artist>-<ensemble>-<composer-or-work>
+```
+
+Examples:
+
+```text
+haitink-rco-berlioz-fantastique
+suzuki-bach-collegium-japan-mozart-great-mass
+kremer-kremerata-baltica-mozart-violin-concertos
+```
+
+When two releases contain the same underlying performance, they may initially be represented by one recording record with release metadata. If release-level differences become important, a later model can separate `performance` from `release`.
+
+## Validation rules
+
+A future validator should check that:
+
+1. every `work_id` resolves to exactly one canonical work;
+2. every artist ID resolves to exactly one canonical artist;
+3. every work status is allowed;
+4. every link status is allowed;
+5. every `last_checked` value is a valid ISO date;
+6. only one recording is `recommended` for a work unless multiple recommendations are explicitly allowed;
+7. a `previous_candidate`, `candidate`, `superseded`, or `unavailable` work is not published automatically;
+8. duplicate service URLs are reported;
+9. a recording with no works or no artists is rejected.
+
+## External recording authorities
+
+MusicBrainz release IDs can be stored as optional external identifiers. They should not replace local recording IDs because:
+
+- one performance may appear on multiple releases;
+- releases can be merged or split in external databases;
+- the repository may model a recommendation at a different level from MusicBrainz.
+
+The pilot therefore keeps nullable authority fields and does not populate them unless the exact release has been verified.

--- a/data/recordings/pilot.yaml
+++ b/data/recordings/pilot.yaml
@@ -1,0 +1,207 @@
+recordings:
+  - id: haitink-rco-berlioz-fantastique
+    title: Berlioz: Symphonie fantastique
+    label: Philips
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      conductor:
+        - bernard-haitink
+      orchestra:
+        - royal-concertgebouw-orchestra
+    works:
+      - work_id: berlioz-op14
+        status: recommended
+        notes: Current recommendation for Symphonie fantastique.
+    links:
+      tidal:
+        status: unverified
+        url:
+        last_checked:
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+    notes: >-
+      Pilot example from issue 61. Release metadata and streaming URL should be populated only
+      after the exact recording has been verified.
+
+  - id: sato-il-pomo-doro-bach-violin-concertos
+    title: Bach: Violin Concertos
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      violin:
+        - shunske-sato
+      ensemble:
+        - il-pomo-doro
+      conductor:
+        - zefira-valova
+    works:
+      - work_id: bach-bwv1041
+        status: recommended
+      - work_id: bach-bwv1042
+        status: recommended
+      - work_id: bach-bwv1043
+        status: candidate
+        notes: Included on the recording but not automatically published as the recommendation.
+    links:
+      tidal:
+        status: active
+        url: http://www.tidal.com/track/95609827
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+    notes: >-
+      Demonstrates one recording containing multiple works with different recommendation statuses.
+
+  - id: mackerras-sco-mozart-late-symphonies
+    title: Mozart: Symphonies Nos. 38-41
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      conductor:
+        - charles-mackerras
+      orchestra:
+        - scottish-chamber-orchestra
+    works:
+      - work_id: mozart-k504
+        status: recommended
+      - work_id: mozart-k543
+        status: recommended
+      - work_id: mozart-k550
+        status: recommended
+      - work_id: mozart-k551
+        status: recommended
+    links:
+      tidal:
+        status: active
+        url: http://www.tidal.com/track/156570988
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+    notes: >-
+      Demonstrates a multi-work recording where all represented works are current recommendations.
+
+  - id: savall-concert-des-nations-beethoven-symphonies
+    title: Beethoven: Symphonies
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      conductor:
+        - jordi-savall
+      orchestra:
+        - le-concert-des-nations
+    works:
+      - work_id: beethoven-op21
+        status: candidate
+      - work_id: beethoven-op36
+        status: candidate
+      - work_id: beethoven-op55
+        status: recommended
+      - work_id: beethoven-op60
+        status: recommended
+      - work_id: beethoven-op67
+        status: recommended
+      - work_id: beethoven-op68
+        status: recommended
+      - work_id: beethoven-op92
+        status: recommended
+      - work_id: beethoven-op93
+        status: recommended
+      - work_id: beethoven-op125
+        status: recommended
+    links:
+      tidal:
+        status: active
+        url: http://www.tidal.com/track/147062218
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+    notes: >-
+      Demonstrates a large recording set with selected works recommended and others retained as candidates.
+
+  - id: previous-candidate-berlioz-fantastique
+    title: Berlioz: Symphonie fantastique — previous candidate
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      conductor:
+        - michael-tilson-thomas
+      orchestra:
+        - san-francisco-symphony
+    works:
+      - work_id: berlioz-op14
+        status: previous_candidate
+        notes: Retained internally for comparison; must not appear as the current public recommendation.
+    links:
+      tidal:
+        status: unavailable
+        url:
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+    notes: >-
+      Explicitly tests that previous candidates remain in the data without becoming public recommendations.
+
+  - id: superseded-mozart-clarinet-concerto
+    title: Mozart: Clarinet Concerto
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      clarinet:
+        - martin-frost
+      ensemble:
+        - amsterdam-sinfonietta
+      conductor:
+        - peter-oundjian
+    works:
+      - work_id: mozart-k622
+        status: superseded
+        notes: Former recommendation retained for history after replacement.
+    links:
+      tidal:
+        status: active
+        url: http://www.tidal.com/track/12128399
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+
+  - id: unavailable-recording-example
+    title: Unavailable recording example
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      conductor:
+        - bernard-haitink
+      orchestra:
+        - royal-concertgebouw-orchestra
+    works:
+      - work_id: berlioz-op14
+        status: unavailable
+        notes: Recording or usable streaming source is no longer available.
+    links:
+      tidal:
+        status: unavailable
+        url:
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:

--- a/data/recordings/pilot.yaml
+++ b/data/recordings/pilot.yaml
@@ -26,31 +26,33 @@ recordings:
       Pilot example from issue 61. Release metadata and streaming URL should be populated only
       after the exact recording has been verified.
 
-  - id: sato-il-pomo-doro-bach-violin-concertos
-    title: Bach: Violin Concertos
+  - id: akamus-bach-brandenburg-concertos
+    title: Bach: Brandenburg Concertos
     label:
     catalog_number:
     year:
     release_year:
     artists:
-      violin:
-        - shunske-sato
       ensemble:
-        - il-pomo-doro
-      conductor:
-        - zefira-valova
+        - akademie-fuer-alte-musik-berlin
     works:
-      - work_id: bach-bwv1041
+      - work_id: bach-bwv1046-2
         status: recommended
-      - work_id: bach-bwv1042
+      - work_id: bach-bwv1047
         status: recommended
-      - work_id: bach-bwv1043
+      - work_id: bach-bwv1048
+        status: recommended
+      - work_id: bach-bwv1049
         status: candidate
         notes: Included on the recording but not automatically published as the recommendation.
+      - work_id: bach-bwv1050-1
+        status: candidate
+      - work_id: bach-bwv1051
+        status: candidate
     links:
       tidal:
         status: active
-        url: http://www.tidal.com/track/95609827
+        url: http://www.tidal.com/track/197388363
         last_checked: 2026-07-10
     identifiers:
       musicbrainz_release_id:
@@ -58,91 +60,39 @@ recordings:
     notes: >-
       Demonstrates one recording containing multiple works with different recommendation statuses.
 
-  - id: mackerras-sco-mozart-late-symphonies
-    title: Mozart: Symphonies Nos. 38-41
+  - id: dinnerstein-bach-goldberg-variations
+    title: Bach: Goldberg Variations
     label:
     catalog_number:
     year:
     release_year:
     artists:
-      conductor:
-        - charles-mackerras
-      orchestra:
-        - scottish-chamber-orchestra
+      piano:
+        - simone-dinnerstein
     works:
-      - work_id: mozart-k504
-        status: recommended
-      - work_id: mozart-k543
-        status: recommended
-      - work_id: mozart-k550
-        status: recommended
-      - work_id: mozart-k551
-        status: recommended
+      - work_id: bach-bwv988
+        status: candidate
+        notes: Candidate recording retained internally until selected as the public recommendation.
     links:
       tidal:
         status: active
-        url: http://www.tidal.com/track/156570988
+        url: http://www.tidal.com/track/24788065
         last_checked: 2026-07-10
     identifiers:
       musicbrainz_release_id:
       discogs_release_id:
-    notes: >-
-      Demonstrates a multi-work recording where all represented works are current recommendations.
 
-  - id: savall-concert-des-nations-beethoven-symphonies
-    title: Beethoven: Symphonies
+  - id: kremer-bach-sonatas-partitas
+    title: Bach: Sonatas and Partitas for Solo Violin
     label:
     catalog_number:
     year:
     release_year:
     artists:
-      conductor:
-        - jordi-savall
-      orchestra:
-        - le-concert-des-nations
+      violin:
+        - gidon-kremer
     works:
-      - work_id: beethoven-op21
-        status: candidate
-      - work_id: beethoven-op36
-        status: candidate
-      - work_id: beethoven-op55
-        status: recommended
-      - work_id: beethoven-op60
-        status: recommended
-      - work_id: beethoven-op67
-        status: recommended
-      - work_id: beethoven-op68
-        status: recommended
-      - work_id: beethoven-op92
-        status: recommended
-      - work_id: beethoven-op93
-        status: recommended
-      - work_id: beethoven-op125
-        status: recommended
-    links:
-      tidal:
-        status: active
-        url: http://www.tidal.com/track/147062218
-        last_checked: 2026-07-10
-    identifiers:
-      musicbrainz_release_id:
-      discogs_release_id:
-    notes: >-
-      Demonstrates a large recording set with selected works recommended and others retained as candidates.
-
-  - id: previous-candidate-berlioz-fantastique
-    title: Berlioz: Symphonie fantastique — previous candidate
-    label:
-    catalog_number:
-    year:
-    release_year:
-    artists:
-      conductor:
-        - michael-tilson-thomas
-      orchestra:
-        - san-francisco-symphony
-    works:
-      - work_id: berlioz-op14
+      - work_id: bach-bwv1001-1006
         status: previous_candidate
         notes: Retained internally for comparison; must not appear as the current public recommendation.
     links:
@@ -154,54 +104,94 @@ recordings:
       musicbrainz_release_id:
       discogs_release_id:
     notes: >-
-      Explicitly tests that previous candidates remain in the data without becoming public recommendations.
+      Explicitly tests that a previous candidate remains in the data without becoming public.
 
-  - id: superseded-mozart-clarinet-concerto
-    title: Mozart: Clarinet Concerto
+  - id: chiaroscuro-beethoven-op18
+    title: Beethoven: String Quartets, Op. 18
     label:
     catalog_number:
     year:
     release_year:
     artists:
-      clarinet:
-        - martin-frost
       ensemble:
-        - amsterdam-sinfonietta
-      conductor:
-        - peter-oundjian
+        - chiaroscuro-quartet
     works:
-      - work_id: mozart-k622
+      - work_id: beethoven-op18
+        status: recommended
+    links:
+      tidal:
+        status: active
+        url: http://www.tidal.com/track/341644410
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+
+  - id: berberian-berio-folk-songs
+    title: Berio: Folk Songs
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      singer:
+        - cathy-berberian
+    works:
+      - work_id: berio-folk-songs
         status: superseded
         notes: Former recommendation retained for history after replacement.
     links:
       tidal:
         status: active
-        url: http://www.tidal.com/track/12128399
+        url: http://www.tidal.com/track/43365184
         last_checked: 2026-07-10
     identifiers:
       musicbrainz_release_id:
       discogs_release_id:
 
-  - id: unavailable-recording-example
-    title: Unavailable recording example
+  - id: gardiner-mozart-requiem
+    title: Mozart: Requiem
     label:
     catalog_number:
     year:
     release_year:
     artists:
       conductor:
-        - bernard-haitink
-      orchestra:
-        - royal-concertgebouw-orchestra
+        - john-eliot-gardiner
     works:
-      - work_id: berlioz-op14
+      - work_id: mozart-k626
         status: unavailable
-        notes: Recording or usable streaming source is no longer available.
+        notes: Recording retained internally, but no longer usable as the current recommendation.
     links:
       tidal:
         status: unavailable
-        url:
+        url: http://www.tidal.com/track/4322229
         last_checked: 2026-07-10
     identifiers:
       musicbrainz_release_id:
       discogs_release_id:
+
+  - id: san-francisco-symphony-adams-orchestral
+    title: John Adams: Orchestral Works
+    label:
+    catalog_number:
+    year:
+    release_year:
+    artists:
+      orchestra:
+        - san-francisco-symphony
+    works:
+      - work_id: adams-common-tones-in-simple-time
+        status: candidate
+      - work_id: adams-short-ride-in-a-fast-machine
+        status: recommended
+    links:
+      tidal:
+        status: redirected
+        url: http://www.tidal.com/track/145452184
+        last_checked: 2026-07-10
+    identifiers:
+      musicbrainz_release_id:
+      discogs_release_id:
+    notes: >-
+      Tests a redirected link and different statuses for works on the same recording.


### PR DESCRIPTION
## Summary

Implements issue #61 as a canonical recording-data pilot.

This PR adds:

- `data/recordings/README.md` documenting the proposed recording format;
- `data/recordings/pilot.yaml` with representative recording records;
- references to canonical work IDs from issue #59;
- references to canonical artist IDs from issue #60;
- per-work recommendation statuses;
- Tidal links with link status and `last_checked` fields;
- explicit support for recordings containing multiple works;
- internal retention of candidates, previous candidates, superseded recommendations, and unavailable recordings.

## Stacked dependency

This PR is based on branch `60-canonical-artist-identities-pilot` because recording records depend on canonical artist IDs. It should be retargeted to `main` after PR #67 is merged, or merged after that PR.

## Pilot coverage

The pilot includes:

- a single-work current recommendation;
- a multi-work recording where some works are recommended and others are candidates;
- a candidate recording;
- a previous candidate that must not be published;
- a superseded recommendation;
- an unavailable recording;
- active, unverified, unavailable, and redirected Tidal-link states.

All artist references in the pilot resolve to IDs introduced in the artist pilot. All work references use canonical work IDs already present in the repository.

## Acceptance criteria

Closes #61
Part of #58

- [x] A proposed recording format is documented.
- [x] The model supports multiple works per recording.
- [x] The model supports references to canonical work IDs.
- [x] The model supports references to canonical artist IDs.
- [x] The model supports Tidal links with status and last-checked fields.
- [x] The model supports previous candidates without making them public recommendations automatically.

## Notes for review

Please review especially:

- whether recommendation status belongs on each work-recording relationship, as proposed;
- whether recording and release should remain one concept for now;
- whether artist roles should remain an open mapping or use a controlled vocabulary;
- whether a service link should point to a track, album, or either;
- whether only one `recommended` recording per work should be enforced by default.
