### PR TITLE
Clarify repository architecture docs

### DIFF
--- a/docs/architecture/adr/0001-work-centric-domain-model.md
+++ b/docs/architecture/adr/0001-work-centric-domain-model.md
@@ -5,8 +5,16 @@ nav_order: 2
 
 # ADR 0001: Work-centric domain model
 
-- Status: Accepted
+- Status: Superseded
 - Date: 2026-07-16
+- Superseded by: `../repository-architecture.md`, `../work.md`,
+  `../performance.md`, `../recommendation-policy.md`
+
+> ADR 0001 established the work-centred direction, but some details below refer
+> to preferred releases and listening links as separate recommendation concerns.
+> The current authoritative design keeps canonical data centred on Person, Work
+> Group, Work and Performance, with release-related details stored only as limited
+> Performance metadata when useful.
 
 ## Context
 

--- a/docs/architecture/adr/0002-domain-entities-and-ownership.md
+++ b/docs/architecture/adr/0002-domain-entities-and-ownership.md
@@ -5,8 +5,15 @@ nav_order: 3
 
 # ADR 0002: Domain entities and ownership
 
-- Status: Accepted
+- Status: Superseded
 - Date: 2026-07-16
+- Superseded by: `../repository-architecture.md`, `../work.md`,
+  `../performance.md`, `../recommendation-policy.md`
+
+> ADR 0002 records an earlier entity split that included Release and
+> Availability. The current authoritative design uses Person, Work Group, Work
+> and Performance as the core canonical entities and does not introduce separate
+> canonical Recording or Release entities.
 
 ## Context
 

--- a/docs/architecture/adr/0003-external-authority-sources.md
+++ b/docs/architecture/adr/0003-external-authority-sources.md
@@ -5,8 +5,15 @@ nav_order: 4
 
 # ADR 0003: External authority sources
 
-- Status: Accepted
+- Status: Superseded
 - Date: 2026-07-16
+- Superseded by: `../repository-architecture.md`,
+  `../recommendation-policy.md`
+
+> ADR 0003 overstates external authority ownership for local identity. The
+> current authoritative design treats external sources as aids for
+> identification, matching and validation; they do not determine canonical
+> repository identity or recommendations.
 
 ## Context
 

--- a/docs/architecture/adr/0004-listening-availability-and-streaming-abstraction.md
+++ b/docs/architecture/adr/0004-listening-availability-and-streaming-abstraction.md
@@ -5,8 +5,14 @@ nav_order: 5
 
 # ADR 0004: Listening availability and streaming abstraction
 
-- Status: Accepted
+- Status: Superseded
 - Date: 2026-07-16
+- Superseded by: `../repository-architecture.md`, `../performance.md`,
+  `../recommendation-policy.md`
+
+> ADR 0004 records an earlier Release and Availability abstraction. The current
+> authoritative design stores streaming links on Performance as limited metadata
+> and does not introduce separate canonical Release or Availability entities.
 
 ## Context
 

--- a/docs/architecture/domain-model.md
+++ b/docs/architecture/domain-model.md
@@ -1,5 +1,12 @@
 # Domain Model
 
+> Status: Superseded by `repository-architecture.md`, `work.md`, `performance.md`,
+> and `recommendation-policy.md`.
+>
+> This document records an earlier conceptual model. The current authoritative
+> model has four core canonical entities: Person, Work Group, Work and
+> Performance. Recording and Release are not separate canonical entities.
+
 ## Purpose
 
 This document defines the conceptual domain model of the music collection.

--- a/docs/architecture/identifier-policy.md
+++ b/docs/architecture/identifier-policy.md
@@ -1,5 +1,11 @@
 # Identifier Policy
 
+> Status: Superseded for Recording and Release identifiers by
+> `repository-architecture.md` and `performance.md`.
+>
+> This document records earlier identifier ideas. The current authoritative
+> canonical model does not create separate Recording or Release identifiers.
+
 ## Purpose
 
 This document defines the identifier strategy used throughout the music collection.

--- a/docs/architecture/identity-rules.md
+++ b/docs/architecture/identity-rules.md
@@ -1,5 +1,12 @@
 # Identity Rules
 
+> Status: Superseded for Performance, Recording and Release identity by
+> `performance.md`.
+>
+> This document records earlier identity rules. The current authoritative design
+> uses Performance as the canonical interpretation entity and does not introduce
+> separate canonical Recording or Release entities.
+
 ## Purpose
 
 This document defines the identity rules for every primary entity in the music collection.

--- a/docs/architecture/information-architecture.md
+++ b/docs/architecture/information-architecture.md
@@ -6,6 +6,15 @@ nav_order: 7
 
 # Information Architecture
 
+> Status: Superseded by `repository-architecture.md`, `work.md`, `performance.md`,
+> and `recommendation-policy.md`.
+>
+> This document records an earlier information model with Recommendation,
+> Release and Availability as separate information entities. The current
+> authoritative architecture keeps canonical data centred on Person, Work Group,
+> Work and Performance. Publication rules are defined in
+> `recommendation-policy.md`.
+
 ## Purpose
 
 This document describes the information architecture of the classical music catalogue.

--- a/docs/architecture/metadata-architecture.md
+++ b/docs/architecture/metadata-architecture.md
@@ -1,5 +1,13 @@
 # Metadata Architecture
 
+> Status: Superseded by `repository-architecture.md`, `work.md`, `performance.md`,
+> and `recommendation-policy.md`.
+>
+> This document records an earlier metadata design that treated Recording and
+> Release as canonical entities. The current authoritative design uses Person,
+> Work Group, Work and Performance as the core canonical entities. Release-related
+> details may exist only as limited Performance metadata when useful.
+
 ## Purpose
 
 This document defines how metadata is represented, maintained, and enriched within the repository.

--- a/docs/architecture/migration-rules.md
+++ b/docs/architecture/migration-rules.md
@@ -1,5 +1,13 @@
 # Migration Rules
 
+> Status: Superseded for entity design by `repository-architecture.md`, `work.md`,
+> `performance.md`, `recommendation-policy.md` and `workflow-design-notes.md`.
+>
+> This document records an earlier migration design that created Recording,
+> Release and Recommendation entities. The current authoritative architecture
+> treats migrated Tidal-linked entries as Performance recommendation candidates
+> and promotes only curatorially accepted Performances into canonical data.
+
 ## Purpose
 
 This document defines how the existing composer Markdown files are migrated into the structured music-collection repository.

--- a/docs/architecture/naming-conventions.md
+++ b/docs/architecture/naming-conventions.md
@@ -1,5 +1,11 @@
 # Naming Conventions
 
+> Status: Superseded for Recording and Release naming by
+> `repository-architecture.md` and `performance.md`.
+>
+> This document records earlier naming guidance. The current authoritative
+> canonical model uses Performance, not separate Recording or Release entities.
+
 ## Purpose
 
 This document defines the naming conventions used for human-readable slugs in the music collection.

--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -2,21 +2,21 @@
 
 ## Purpose
 
-A `Performance` represents one curatorially accepted interpretation of one musical `Work`.
+A `Performance` represents one curatorially accepted interpretation of exactly one `Work`.
 
 It is the repository object that connects:
 
-- a single Work;
+- one Work;
 - the performers responsible for the interpretation;
-- the curator's recommendation;
-- one or more links through which the Performance may be accessed;
-- optional references such as a Gramophone review.
+- optional links through which the Performance may be accessed;
+- optional references such as a Gramophone review;
+- sparse metadata needed for recognition, matching, maintenance or presentation.
 
-The term `Performance` is used as a practical collection concept. It may correspond externally to what another source calls a recording, track, album item, release, or performance event.
+The term `Performance` is a practical collection concept. It may correspond externally to what another source calls a recording, track, album item, release or performance event.
 
-The repository does not maintain separate canonical entities for Recording and Release unless a future, demonstrated requirement makes that necessary.
+The repository does not maintain separate canonical Recording or Release entities.
 
-## Core principle
+## Core rule
 
 A Performance always refers to exactly one Work.
 
@@ -26,13 +26,13 @@ Performance
 exactly one Work
 ```
 
-A Tidal album may contain several Works, but each Work represented in that album is modelled as a separate Performance.
+A Tidal album may contain several Works. Each accepted interpretation of a Work is modelled as a separate Performance.
 
-A single canonical Performance must never contain multiple `work_id` values.
+A canonical Performance must never contain multiple `work_id` values and must never point only to a Work Group.
 
 ## Curatorial boundary
 
-A Performance enters canonical repository data only after it has been listened to and judged good enough to recommend.
+A Performance enters canonical data only after the curator has listened to it and judged it good enough to recommend.
 
 Candidate Performances that have not yet been heard or accepted do not belong in `data/performances/`.
 
@@ -43,7 +43,7 @@ They may temporarily exist in:
 - a migration review file;
 - an external matching result.
 
-The canonical repository contains accepted Performances, not listening queues.
+Canonical data contains accepted Performances, not listening queues.
 
 ## Identity
 
@@ -71,23 +71,9 @@ Typical indicators include:
 - a different performance event or studio interpretation;
 - a materially different recorded interpretation of the same Work.
 
-When identity remains uncertain, the repository should not silently create a duplicate. The case should be reported for review.
+When identity remains uncertain, the repository should report the case for review rather than silently creating a duplicate.
 
-## Relationship to Work
-
-Each Performance must contain one valid `work_id`.
-
-```yaml
-work_id: martin-symphonie-concertante
-```
-
-The referenced Work must already exist in `data/works/`.
-
-If a new Performance is discovered for a Work that does not yet exist, the Work must be created first.
-
-A Performance may refer to a version-specific Work. It must never point only to a Work Group.
-
-## Relationship to performers
+## Performers
 
 A Performance records the performers needed to identify and present the interpretation.
 
@@ -102,47 +88,36 @@ Possible roles include:
 - instrumentalist;
 - accompanist.
 
-The exact role structure should remain flexible enough to represent orchestral music, chamber music, piano music, vocal music, and unusual ensembles.
+The exact role structure should remain flexible enough to represent orchestral music, chamber music, piano music, vocal music and unusual ensembles.
 
-Performers that have stable canonical identities should refer to `Person` or ensemble identifiers rather than relying only on free text.
-
-Illustrative examples:
-
-```yaml
-performers:
-  conductor: bernard-haitink
-  orchestra: royal-concertgebouw-orchestra
-```
-
-```yaml
-performers:
-  ensemble: alban-berg-quartett
-```
-
-```yaml
-performers:
-  piano: alfred-brendel
-```
-
-The final schema may choose either role keys or an ordered list of role assignments. The architectural requirement is that performer identity remains clear and machine-readable.
+Performers with stable canonical identities should refer to Person or ensemble identifiers rather than relying only on free text.
 
 ## Recommendation semantics
 
 Every canonical Performance is recommended.
 
-The repository therefore does not need a field such as:
+Presence in `data/performances/` should therefore imply recommendation. A field such as:
 
 ```yaml
 recommended: true
 ```
 
-if presence in `data/performances/` already implies recommendation.
+is redundant and should be avoided unless a temporary migration requirement makes it necessary.
 
-A separate recommendation flag should only be retained if required for migration compatibility or future support of non-recommended historical Performances.
+Publication rules, comparison categories and replacement policy are defined in `recommendation-policy.md`.
 
-The preferred initial rule is:
+## Performance profiles
 
-> A Performance file in canonical data represents an accepted recommendation.
+A performance profile belongs to a Performance, not to a Work.
+
+It is used only when a musically meaningful distinction should preserve more than one public recommendation for the same Work.
+
+Example:
+
+- Bach keyboard concerto, piano;
+- Bach keyboard concerto, harpsichord.
+
+Profiles should remain sparse. The repository should not introduce a large predefined taxonomy.
 
 ## Keep looking
 
@@ -154,58 +129,13 @@ This is represented by a simple boolean:
 keep_looking: true
 ```
 
-Its meaning is:
+Its meaning is only:
 
-> This Performance is currently recommended, but the curator wishes to remain alert for a better alternative.
+> This Performance is currently recommended, but the curator remains open to finding a better recommendation.
 
-No explanation is required.
+No explanation, score, stars, reason code or artistic/technical assessment is required.
 
-The repository does not need to store:
-
-- a quality score;
-- stars;
-- separate artistic and technical assessments;
-- a justification;
-- a reason code.
-
-When `keep_looking` is absent or false, no active search is implied.
-
-A list of Performances marked `keep_looking: true` may be generated automatically.
-
-No GitHub issue should be created automatically from this flag.
-
-## Alternative search workflow
-
-Searching for alternatives is manually triggered per Work.
-
-Only then may the system:
-
-1. search external sources;
-2. suggest plausible alternatives;
-3. create a GitHub issue for comparison;
-4. wait for listening and editorial judgement.
-
-This pull-based model prevents the repository from generating a large backlog of inactive issues.
-
-Alternative candidates remain non-canonical until they have been heard and accepted.
-
-## Replacement and comparison
-
-When a new accepted Performance is added for a Work that already has a recommended Performance, the existing recommendation must not be overwritten automatically.
-
-A comparison issue should be created only when the curator is actively considering both.
-
-Possible outcomes include:
-
-- retain the existing Performance;
-- replace it with the new Performance;
-- temporarily retain both;
-- determine that both entries represent the same Performance;
-- reject the new candidate.
-
-The repository should not assume that each Work can permanently have only one Performance unless that editorial rule is established elsewhere.
-
-The public site may nevertheless choose to present one preferred Performance prominently.
+`keep_looking: true` must not automatically create searches or GitHub Issues. A generated report may list these Performances.
 
 ## Platform links
 
@@ -225,17 +155,7 @@ Therefore:
 - multiple platform links may refer to the same Performance;
 - a Performance may remain canonical even when no active platform link exists.
 
-Optional operational metadata may include:
-
-```yaml
-links:
-  tidal:
-    url: https://tidal.com/...
-    status: active
-    last_checked: 2026-07-19
-```
-
-Such operational fields are secondary and may be maintained by automated checks.
+Operational fields such as link status or last-checked dates may be maintained outside canonical data or stored only when later schema design finds them necessary.
 
 ## Gramophone references
 
@@ -247,17 +167,9 @@ Legacy notation such as:
 (10/2021)
 ```
 
-means that the Performance was reviewed in the October 2021 issue of *Gramophone*.
+means that the Performance was reviewed in the October 2021 issue of `Gramophone`.
 
-Preferred representation:
-
-```yaml
-reviews:
-  gramophone:
-    issue: 2021-10
-```
-
-When available:
+Preferred representation may later be:
 
 ```yaml
 reviews:
@@ -266,14 +178,7 @@ reviews:
     url: https://...
 ```
 
-The repository stores only the reference.
-
-It does not store:
-
-- the review text;
-- extracted ratings;
-- extended quotations;
-- a complete review ontology.
+The repository stores only the reference. It does not store review text, extracted ratings, extended quotations or a complete review ontology.
 
 ## Optional disambiguating metadata
 
@@ -286,69 +191,12 @@ Examples include:
 - recording location;
 - label;
 - catalogue number;
-- source album title.
+- source album title;
+- stable external identifiers.
 
-These fields are optional.
+These fields are optional and do not define canonical identity.
 
 They should not be added merely because an external source provides them.
-
-> Retain disambiguating metadata only when it materially helps recognition, matching, maintenance, or presentation.
-
-## External identifiers
-
-Stable external identifiers may be stored when useful.
-
-```yaml
-external_ids:
-  musicbrainz_recording: ...
-  musicbrainz_release: ...
-  discogs_release: ...
-```
-
-External identifiers are references, not identity authorities.
-
-A single Performance may legitimately point to identifiers from different external entity types because external databases model the same material differently.
-
-The repository remains authoritative for the Performance identity.
-
-## Suggested minimal structure
-
-```yaml
-id: example-performance
-work_id: example-work
-
-performers:
-  conductor: example-conductor
-  orchestra: example-orchestra
-
-keep_looking: false
-
-links:
-  tidal:
-    url: https://tidal.com/...
-
-reviews:
-  gramophone:
-    issue: 2021-10
-    url: https://...
-```
-
-For a Performance where a better alternative would be welcome:
-
-```yaml
-id: martin-symphonie-concertante-example
-work_id: martin-symphonie-concertante
-
-performers:
-  conductor: example-conductor
-  orchestra: example-orchestra
-
-keep_looking: true
-
-links:
-  tidal:
-    url: https://tidal.com/...
-```
 
 ## Required fields
 
@@ -358,44 +206,25 @@ The initial required fields are:
 - `work_id`;
 - `performers`.
 
-At least one performer relationship must be present.
+At least one performer relationship must be present. A platform link is not required.
 
-A platform link is not required.
+Exact YAML syntax is deferred to later schema design.
 
-`keep_looking` defaults to `false` when omitted.
+## Migration implications
 
-## Optional fields
+During migration:
 
-Possible optional fields include:
+- each legacy accepted Tidal-linked entry is interpreted as a Performance recommendation candidate;
+- the associated Work must be identified first;
+- performer names must be normalised;
+- existing Gramophone references must be preserved;
+- duplicate representations of the same interpretation must be detected;
+- migration must not infer quality scores or reasons;
+- `keep_looking` should be set only where explicitly decided by the curator.
 
-- `year`;
-- `links`;
-- `reviews`;
-- `external_ids`;
-- limited disambiguating release information;
-- `keep_looking`.
+Playlist imports may contain multiple Performances of the same Work. They should be retained in migration review artefacts or GitHub Issues until the curator decides which Performance becomes canonical for the relevant comparison category.
 
-Optional fields should remain sparse.
-
-## File location
-
-Each Performance is stored in a separate canonical file:
-
-```text
-data/performances/<performance-id>.yaml
-```
-
-Example:
-
-```text
-data/performances/haitink-rco-bruckner-8.yaml
-```
-
-The filename should match the stable repository identifier.
-
-Display names may change without requiring a new identifier.
-
-## Validation rules
+## Validation
 
 At minimum, validation should ensure that:
 
@@ -412,59 +241,19 @@ At minimum, validation should ensure that:
 
 Validation should detect uncertainty, not resolve it silently.
 
-## Migration implications
-
-During migration from the existing Markdown files:
-
-- each accepted Tidal-linked entry becomes a Performance candidate;
-- the associated Work must be identified;
-- performer names must be normalised;
-- existing Gramophone references must be preserved;
-- duplicate representations of the same interpretation must be detected;
-- migration must not infer quality scores or reasons;
-- `keep_looking` should only be set where explicitly decided by the curator.
-
-Playlist imports may contain multiple Performances of the same Work.
-
-These should be retained for review rather than automatically collapsed.
-
 ## Website presentation
 
 The website user should normally see only:
 
 - the Work;
 - the relevant performers;
-- the Tidal link, when available;
+- the streaming link, when available;
 - the Gramophone review link, when available.
 
-Internal fields such as external identifiers, link-check timestamps, migration notes, duplicate-detection data, and `keep_looking` do not need to be publicly visible.
-
-The public website may present a single preferred Performance or multiple Performances depending on later editorial policy.
-
-## Deferred questions
-
-The following choices may be finalised during schema design without changing this entity definition:
-
-- exact YAML syntax for performer roles;
-- whether ensembles are modelled as Persons or as a separate entity;
-- whether more than one current recommended Performance may be publicly shown for one Work;
-- whether historical superseded Performances remain canonical;
-- which operational link-status fields are committed to Git;
-- which external identifier types are supported initially.
-
-These are implementation and policy decisions, not reasons to split Performance into Recording and Release.
+Internal fields such as external identifiers, link-check timestamps, migration notes, duplicate-detection data and `keep_looking` do not need to be publicly visible.
 
 ## Summary
 
-A Performance is:
+A Performance is one accepted interpretation of exactly one Work.
 
-- one accepted interpretation;
-- of exactly one Work;
-- identified by its performers and limited disambiguating metadata;
-- optionally linked to Tidal and Gramophone;
-- optionally marked `keep_looking: true`;
-- canonical only after it has been heard and accepted.
-
-The repository stores durable curator knowledge.
-
-Unheard candidates, active searches, comparisons, and temporary alternatives remain outside canonical Performance data until an editorial decision has been made.
+It is canonical only after listening and editorial acceptance. Unheard candidates, active searches, comparisons and temporary alternatives remain outside canonical Performance data until an editorial decision has been made.

--- a/docs/architecture/pilot-domain-model.md
+++ b/docs/architecture/pilot-domain-model.md
@@ -1,5 +1,12 @@
 # Pilot Domain Model
 
+> Status: Superseded for entity design by `repository-architecture.md`, `work.md`,
+> `performance.md` and `recommendation-policy.md`.
+>
+> This pilot records earlier modelling experiments involving Recording and
+> Release. The current authoritative design does not introduce separate
+> canonical Recording or Release entities.
+
 ## Purpose
 
 This document models a pilot set of twenty deliberately difficult cases drawn from the existing composer files.

--- a/docs/architecture/recommendation-policy.md
+++ b/docs/architecture/recommendation-policy.md
@@ -4,94 +4,69 @@
 
 This document defines the editorial rules that determine how recommended Performances are selected, compared and published.
 
-It deliberately does **not** define the structure of a Work or a Performance. Those are specified elsewhere. This document describes the curator's decision process.
-
----
+It does not define Work or Performance structure. Those entity boundaries are defined in `work.md` and `performance.md`.
 
 ## Guiding principle
 
 The repository is not a catalogue of available recordings.
 
-It is a curated collection of recommendations.
+It is a curated collection of recommendations. The goal is to identify the Performance that is currently recommended for each comparison category.
 
-The goal is therefore not to identify every existing Performance, but to identify the Performance that is currently recommended.
-
----
-
-## One public recommendation
-
-For every comparison category there is exactly one published recommendation.
-
-Visitors come to the website for a recommendation, not for a list of options.
-
-Other music services already provide exhaustive catalogues.
-
----
+Recommendations must never be replaced automatically.
 
 ## Comparison categories
 
-Recommendations are compared only within the same comparison category.
+For every comparison category there is one public recommendation.
 
-A comparison category consists of:
+A comparison category consists conceptually of:
 
 - one Work;
-- one performance profile (when applicable).
+- one performance profile, when a performance profile is relevant.
 
-For most Works there is only one comparison category.
-
-Example:
-
-    Ravel – Boléro
-
-For some Works multiple performance traditions exist.
+For most Works no explicit performance profile is needed.
 
 Example:
 
-    Bach – Keyboard Concerto BWV 1052
-        Piano
-        Harpsichord
+```text
+Ravel - Bolero
+```
 
-Each performance profile has its own recommendation.
+Some Works may legitimately have more than one public recommendation because different performance traditions should not be treated as alternatives.
 
-The workflow must never compare Performances from different performance profiles.
+Example:
 
----
+```text
+Bach - Keyboard Concerto BWV 1052
+    piano
+    harpsichord
+```
+
+The harpsichord Performance must not automatically be treated as a replacement candidate for the piano Performance.
 
 ## Performance profiles
 
-A performance profile is introduced only when it represents a musically meaningful distinction that the curator wishes to preserve.
+A performance profile belongs to a Performance, not to a Work.
 
-Examples include piano and harpsichord.
+A profile may be proposed from available metadata, such as instrument credits, but not all curatorially relevant distinctions can reliably be inferred from metadata. The final profile is therefore an explicit canonical classification.
 
-Performance profiles should remain exceptional rather than becoming a general classification system.
+Performance profiles should remain sparse and should be introduced only when a musically meaningful distinction needs to be preserved.
 
----
+The repository should not create a large predefined taxonomy of performance profiles.
 
 ## Candidate Performances
 
 A newly discovered Performance is never accepted automatically.
 
-Workflow:
+The normal comparison workflow is:
 
 1. Identify the Work.
-2. Determine the performance profile (if any).
+2. Determine the performance profile, if any.
 3. Locate the current recommendation in that comparison category.
-4. Create a comparison issue if necessary.
+4. Create one comparison issue if necessary.
 5. Listen.
 6. Make an editorial decision.
 
----
-
-## Temporary dual recommendations
-
-During evaluation there may temporarily be:
-
-- current recommendation;
-- candidate recommendation.
-
-After the decision there is again exactly one published recommendation within that comparison category.
-
----
+Candidate Performances remain outside canonical data until accepted.
 
 ## Editorial decisions
 
@@ -100,65 +75,53 @@ After comparison the curator may:
 - retain the existing recommendation;
 - replace it with the candidate;
 - conclude both represent the same Performance;
-- reject the candidate.
+- reject the candidate;
+- keep both only when they belong to different comparison categories.
 
-The repository never replaces recommendations automatically.
-
----
+During comparison there may temporarily be a current recommendation and a candidate. After editorial judgement, only one recommendation remains public within that comparison category.
 
 ## Keep looking
 
 Some recommendations are satisfactory but not definitive.
 
-Example:
-
 ```yaml
 keep_looking: true
 ```
 
-This indicates only that the curator would welcome a better recommendation.
+This indicates only that the curator remains open to finding a better recommendation.
 
-It does not trigger automatic searches or GitHub issues.
+It does not require an explanation, score, stars, reason code or artistic/technical assessment.
 
----
+It does not trigger automatic searches or GitHub Issues.
 
-## Alternative searches
+A generated report may list Performances marked `keep_looking: true`.
 
-Searching for alternatives is always initiated manually.
+## Searching for alternatives
 
-The system may then:
+Searching for alternative Performances is always manually initiated by the curator, per Work.
 
-1. search external sources;
-2. propose candidate Performances;
-3. create a single GitHub issue for review.
+A manual request may lead to:
 
-This pull-based workflow prevents large backlogs.
+1. an external search;
+2. a small set of candidate Performances;
+3. one GitHub issue for comparison;
+4. listening;
+5. an editorial decision.
 
----
+Do not design automatic searches or automatic GitHub issue creation for every Work or Performance marked as improvable.
 
 ## Website policy
 
 The public website normally displays only the current recommendation for each comparison category.
 
-Candidates, workflow state and internal maintenance information are not shown.
+Visitors should receive a clear recommendation rather than a catalogue of all available Performances.
 
----
-
-## Design principles
-
-1. The repository stores durable editorial knowledge.
-2. Editorial judgement is never automated.
-3. Comparisons occur only within the same comparison category.
-4. Recommendations are replaced only after explicit review.
-5. Workflow state belongs in GitHub Issues, not canonical data.
-6. Simplicity takes precedence over exhaustive classification.
-
----
+Candidates, workflow state, matching evidence, migration state, link-check data and `keep_looking` are not normally shown.
 
 ## Summary
 
-The repository answers one question:
+The repository answers one editorial question:
 
-> Which Performance do I currently recommend?
+> Which Performance do I currently recommend for this Work and, where relevant, this performance profile?
 
-Everything else belongs to the editorial workflow rather than the canonical collection.
+Everything else belongs to the editorial workflow rather than the public recommendation.

--- a/docs/architecture/repository-architecture.md
+++ b/docs/architecture/repository-architecture.md
@@ -2,92 +2,47 @@
 
 ## Purpose
 
-This document defines the physical and logical organisation of the repository.
+This document defines the repository-level architecture for the classical music recommendation collection.
 
-The repository supports a curated collection of classical Works and recommended Performances. It is not intended to reproduce the entity models or metadata coverage of MusicBrainz, Discogs, Tidal, Gramophone, Wikipedia, or other external sources.
+The repository is a curated recommendation collection, not an exhaustive catalogue of recordings, releases, tracks, albums or external authority records. It stores durable curator knowledge that is needed to identify Works, preserve recommendations, maintain links and generate the public website.
 
-The architecture should remain proportionate to the public website:
+Detailed entity boundaries are defined in:
 
-- the user browses Composers and Works;
-- a Work may be marked as a Gem;
-- a Work may have one or more recommended Performances;
-- a Performance may contain a Tidal link;
-- a Performance may contain a link to a Gramophone review.
+- `work.md`;
+- `performance.md`;
+- `recommendation-policy.md`.
 
-Everything else exists only to support accurate identification, maintenance, migration, validation, and publication.
+Operational workflows are described in `workflow-design-notes.md`.
 
----
+## Architectural principles
 
-## Design principles
+### Repository authority
 
-### 1. The repository represents the collection
+The canonical repository is authoritative for local identity and editorial recommendations.
 
-The repository is the canonical representation of the curated collection.
+External sources such as MusicBrainz, Discogs, Wikidata, Wikipedia, Tidal and Gramophone may help with identification, matching and validation. They do not determine canonical identity and must not create, remove or replace recommendations automatically.
 
-The existing Markdown files are the starting point and are assumed to be substantially correct. Migration should preserve their editorial meaning unless a genuine identity problem is found.
+### Curated scope
 
-External sources may help identify, validate, or enrich entities. They do not replace the repository's own canonical identities or recommendations.
+The repository should represent:
 
-### 2. Accuracy before completeness
+- selected Persons;
+- selected Work Groups;
+- selected Works;
+- curatorially accepted Performances;
+- minimal external references and links needed for matching, maintenance or presentation.
 
-The repository must be certain about the identity of:
+It should not accumulate metadata merely because an external source provides it.
 
-- a Person;
-- a Composer;
-- a Work;
-- a version, arrangement, orchestration, revision, or completion represented as a separate Work;
-- a recommended Performance.
+### Durable canonical data
 
-Metadata completeness is secondary.
+Only durable curator knowledge belongs in canonical data.
 
-The repository should not collect information merely because an external source makes it available.
+Temporary candidates, listening queues, searches, comparisons, migration review artefacts, duplicate evidence and other workflow state remain outside canonical data. They may live in GitHub Issues, generated reports or temporary migration artefacts.
 
-### 3. Minimal persistent data
+### No canonical Recording or Release entities
 
-Only information that serves at least one of the following purposes should be stored persistently:
-
-- identifying an entity;
-- distinguishing it from another entity;
-- representing an editorial recommendation;
-- supporting the public website;
-- maintaining an external link;
-- documenting a consequential identity decision.
-
-Temporary metadata used during matching or migration belongs outside the canonical data model.
-
-### 4. Repository-first identification
-
-When a new Tidal link is introduced, the repository is consulted first.
-
-The preferred sequence is:
-
-```text
-Tidal link
-    ↓
-Existing Person and Work data
-    ↓
-Existing Performance data
-    ↓
-External sources, only where needed
-    ↓
-Human review, only when identity remains uncertain
-```
-
-Existing canonical entities should be reused whenever possible.
-
-### 5. External ontologies are not copied
-
-MusicBrainz distinguishes Works, Recordings, Releases, Tracks, and other entities for its own purposes. Discogs organises Releases and Masters. Tidal exposes Tracks and Albums.
-
-This repository uses only the distinctions required by the collection.
-
-In particular, it does not maintain separate internal entities for Performance, Recording, and Release.
-
----
-
-## Core domain objects
-
-The persistent collection is organised around the following core objects:
+The initial canonical model has four core entities:
 
 ```text
 Person
@@ -96,97 +51,73 @@ Work
 Performance
 ```
 
-Recommendations are represented as editorial properties or records attached to Works and Performances.
+The repository does not introduce separate canonical Recording or Release entities. Limited release-related details may be stored on a Performance when useful for recognition, matching, maintenance or presentation, but they do not define Performance identity.
+
+## Core entities
 
 ### Person
 
 A Person represents an individual.
 
-Composer is a role of a Person, not a separate entity type. A Person may also act as conductor, soloist, arranger, orchestrator, editor, librettist, or completer.
+Composer is a role of a Person, not a separate canonical entity type. A Person may also act as conductor, soloist, arranger, orchestrator, editor, librettist or completer.
 
-The repository must avoid duplicate Person identities caused by:
-
-- alternative spellings;
-- diacritics;
-- transliterations;
-- initials;
-- pseudonyms;
-- historical name forms;
-- identical names belonging to different people.
+Person records exist to avoid duplicate identities caused by spelling variants, diacritics, transliterations, initials, pseudonyms, historical name forms or identical names belonging to different people.
 
 ### Work Group
 
 A Work Group is a non-performable grouping of closely related Works.
 
-It is created only when the collection represents multiple musically meaningful versions or derivations that users should understand as belonging together.
+Every Work belongs to exactly one Work Group. A Work Group may contain one Work, but it becomes musically important when the collection represents multiple versions or derivations that should be understood together.
 
-Examples may include:
-
-- materially different versions of the same symphony;
-- an original Work and a later independently performed revision.
-
-A Performance is never linked directly to a Work Group.
+A Performance never links directly to a Work Group.
 
 ### Work
 
-A Work is a performable musical entity.
+A Work represents one distinct artistic composition or version.
 
-Separate Works are created for musically meaningful and independently performable:
+Every Work belongs to exactly one Work Group. Composer revisions are separate Works within the same Work Group. Different performers, recordings, releases, labels, remasters or streaming links do not create new Works.
 
-- versions;
-- arrangements;
-- orchestrations;
-- revisions;
-- completions.
+A Work may exist without any recommended Performance and must still be eligible for display on the website.
 
-Editorial corrections, remastering, or minor source differences do not create a new Work.
+The Work-level public presentation attribute is:
 
-A Work may be marked as a Gem.
+```yaml
+gem: true
+```
 
-The identity of every Work on the website must be unambiguous.
+`gem` must not affect workflow, validation or prioritisation.
 
 ### Performance
 
-A Performance represents the recommended interpretation as recognised by the curator and the website user.
+A Performance represents one curatorially accepted interpretation of exactly one Work.
 
-It combines the concepts that external databases may separately describe as a performance, recording, release, track, or album manifestation.
+A Performance enters canonical data only after the curator has listened to it and judged it good enough to recommend. A changed Tidal URL, reissue, remaster, alternative digital release or different album containing the same interpretation does not create a new Performance.
 
-A Performance normally includes:
-
-- the Work performed;
-- relevant performers;
-- optional disambiguating information such as a year;
-- zero or more platform links;
-- an optional Gramophone review reference;
-- recommendation status.
-
-The term `Performance` is used in the repository as a practical collection concept. It does not imply that every recorded item is a single documented live event.
-
----
+Presence in canonical Performance data implies recommendation. A separate field such as `recommended: true` should be avoided unless a temporary migration requirement makes it necessary.
 
 ## Public model
 
-The public website is built around the following hierarchy:
+The public website should ordinarily show:
 
-```text
-Person in the role of Composer
-    ↓
-Work
-    ↓
-recommended Performance
-    ↓
-Tidal link, when available
-    ↓
-Gramophone review link, when available
-```
+- the Work;
+- the recommended performers;
+- the relevant streaming link;
+- an optional Gramophone reference or link.
 
-The user does not need to navigate separate Recording and Release entities.
+Visitors should receive a clear recommendation rather than a catalogue of all available Performances.
 
-The public presentation should not expose internal migration, matching, cache, or validation structures.
+The website should not normally expose:
 
----
+- internal identifiers;
+- candidate Performances;
+- migration state;
+- matching evidence;
+- link-check data;
+- `keep_looking`.
 
-## Proposed top-level layout
+## Repository layers
+
+The proposed top-level layout is:
 
 ```text
 .
@@ -201,13 +132,11 @@ The public presentation should not expose internal migration, matching, cache, o
 └── tests/
 ```
 
-The exact static-site directory may later be adapted to the technology used by GitHub Pages. The architectural distinction between canonical data, source material, generated output, and temporary data should remain.
-
----
+The exact static-site directory may later be adapted to the technology used for GitHub Pages. The distinction between canonical data, source material, generated output and temporary data should remain.
 
 ## `data/`: canonical collection data
 
-The `data/` directory contains the persistent, canonical representation of the collection.
+The `data/` directory contains reviewed, accepted collection data.
 
 ```text
 data/
@@ -217,671 +146,39 @@ data/
 └── performances/
 ```
 
-Only reviewed and accepted collection data belongs here.
-
-### `data/persons/`
-
-Contains one file per Person.
-
-Example:
-
-```text
-data/persons/
-└── anton-bruckner.yaml
-```
-
-Illustrative structure:
-
-```yaml
-id: anton-bruckner
-name: Anton Bruckner
-
-external_ids:
-  musicbrainz: ...
-  wikidata: ...
-```
-
-Additional information is stored only when needed for identification or presentation.
-
-A complete biography, discography, nationality profile, or list of aliases is not required.
-
-### `data/work-groups/`
-
-Contains one file per Work Group.
-
-Example:
-
-```text
-data/work-groups/
-└── bruckner-symphony-8.yaml
-```
-
-Illustrative structure:
-
-```yaml
-id: bruckner-symphony-8
-composer_id: anton-bruckner
-title: Symphony No. 8 in C minor
-
-members:
-  - bruckner-symphony-8-1887
-  - bruckner-symphony-8-1890
-```
-
-Work Groups remain exceptional and should not be created for every Work.
-
-### `data/works/`
-
-Contains one file per Work.
-
-Example:
-
-```text
-data/works/
-└── bruckner-symphony-8-1890.yaml
-```
-
-Illustrative structure:
-
-```yaml
-id: bruckner-symphony-8-1890
-composer_id: anton-bruckner
-title: Symphony No. 8 in C minor
-version: 1890
-catalogue_number: WAB 108
-work_group_id: bruckner-symphony-8
-gem: true
-
-relationships:
-  - type: revision_of
-    target_work_id: bruckner-symphony-8-1887
-```
-
-The exact schema belongs in the domain and metadata documentation. The repository architecture only requires that each Work has a stable, independent canonical record.
-
-### `data/performances/`
-
-Contains one file per Performance.
-
-Example:
-
-```text
-data/performances/
-└── haitink-rco-bruckner-8.yaml
-```
-
-Illustrative structure:
-
-```yaml
-id: haitink-rco-bruckner-8
-work_id: bruckner-symphony-8-1890
-
-performers:
-  conductor: bernard-haitink
-  orchestra: royal-concertgebouw-orchestra
-
-year: 1981
-recommended: true
-
-links:
-  tidal:
-    url: ...
-    status: active
-
-reviews:
-  gramophone:
-    issue: 1981-10
-    url: ...
-```
-
-The `year` and other disambiguating metadata are optional. They should be included only when useful for recognition, matching, or display.
-
-A Performance may exist without a current Tidal link. The recommendation is not identical to platform availability.
-
----
-
-## Recommendation representation
-
-The current collection contains two distinct editorial judgements.
-
-### Work recommendation
-
-The diamond symbol in the legacy Markdown represents a Work-level recommendation:
-
-```yaml
-gem: true
-```
-
-### Performance recommendation
-
-A legacy entry containing a Tidal link represents recommendation of that Performance:
-
-```yaml
-recommended: true
-```
-
-These meanings must remain distinct during migration.
-
-External sources may not create, remove, or modify either recommendation automatically.
-
-If later requirements justify a separate Recommendation entity, the data may be refactored without changing this editorial distinction. A separate entity is not required for the initial repository design.
-
----
-
-## Platform links
-
-Platform links belong to a Performance.
-
-Example:
-
-```yaml
-links:
-  tidal:
-    url: ...
-    status: active
-    last_checked: 2026-07-17
-```
-
-Additional platforms may later be added under the same structure.
-
-A platform link is a route to a Performance, not the identity of the Performance itself.
-
-Consequently:
-
-- a broken Tidal link does not invalidate the Performance;
-- replacement of a Tidal URL does not create a new Performance;
-- equivalent links on multiple platforms may refer to the same Performance.
-
-Platform-specific metadata should remain minimal.
-
----
-
-## Gramophone references
-
-Gramophone information is represented only as a reference to a review of a Performance.
-
-Legacy notations such as:
-
-```text
-(10/2021)
-```
-
-mean that the Performance was reviewed in the October 2021 issue of *Gramophone*.
-
-During migration this may become:
-
-```yaml
-reviews:
-  gramophone:
-    issue: 2021-10
-```
-
-When the review URL is known:
-
-```yaml
-reviews:
-  gramophone:
-    issue: 2021-10
-    url: ...
-```
-
-The repository does not need to store:
-
-- review text;
-- quotations;
-- star ratings inferred from the review;
-- an extensive critical reception model;
-- complete issue contents.
-
-The review link is contextual information attached to the Performance.
-
----
+The exact YAML schema is deferred. The architectural requirement is that each canonical entity has one stable local identity and belongs to the correct directory.
 
 ## `sources/`: retained source material
 
-The `sources/` directory contains material used to construct, verify, or enrich the collection but not itself part of the canonical domain data.
+The `sources/` directory contains material used to construct, verify or enrich the collection but not itself part of canonical data.
 
-Suggested layout:
+Examples include:
 
-```text
-sources/
-├── legacy-markdown/
-├── lucas-grove/
-└── references/
-```
+- preserved legacy Markdown;
+- exported Tidal playlists;
+- historical Word documents;
+- manually retained reference material.
 
-### `sources/legacy-markdown/`
+Source material may guide migration and review, but values become canonical only when deliberately promoted into `data/`.
 
-Contains the original or preserved Markdown collection during migration.
+## `generated/`, `cache/` and `reports/`
 
-These files remain the authoritative migration source for:
+Generated output, caches and reports are not canonical data.
 
-- existing Work selections;
-- Gem markers;
-- recommended Performance entries;
-- existing Tidal links;
-- existing Gramophone issue references.
+They may contain:
 
-After migration they may remain as archival source material, but the canonical website should be generated from `data/`.
+- candidate Performances;
+- search results;
+- matching evidence;
+- duplicate reports;
+- `keep_looking` reports;
+- link-check reports;
+- migration review files.
 
-### `sources/lucas-grove/`
+These artefacts support workflow decisions. They do not define repository identity or public recommendations.
 
-Contains the curator's historical Word documents about selected Composers.
+## `site/`
 
-These documents are an internal authority source. They may help with:
+The website is generated from canonical data.
 
-- Composer identity;
-- Work identity;
-- preferred titles;
-- version distinctions;
-- historical editorial context.
-
-They should not be treated as canonical entity files in their present Word format.
-
-A later conversion process may transform them into a more usable format, for example:
-
-```text
-sources/lucas-grove/converted/
-```
-
-or:
-
-```text
-generated/lucas-grove/
-```
-
-The converted output should remain source or research material unless specific values are deliberately promoted into canonical `data/` records.
-
-Conversion by Codex or another tool should preserve:
-
-- document identity;
-- headings and structure;
-- source filename;
-- traceability to the original Word file.
-
-It should not automatically rewrite canonical Works or Persons.
-
-### `sources/references/`
-
-May contain manually maintained references, notes, or source pointers that do not belong to a single canonical entity.
-
-This directory should remain limited and purposeful.
-
----
-
-## `docs/`: architecture and editorial policy
-
-The `docs/` directory contains human-readable documentation.
-
-Suggested layout:
-
-```text
-docs/
-├── architecture/
-└── editorial/
-```
-
-### `docs/architecture/`
-
-Includes documents such as:
-
-- `domain-model.md`
-- `identity-rules.md`
-- `naming-conventions.md`
-- `identifier-policy.md`
-- `migration-rules.md`
-- `validation-rules.md`
-- `metadata-architecture.md`
-- `repository-architecture.md`
-
-Workflow documents may be added later, after the repository structure is stable.
-
-### `docs/editorial/`
-
-May contain policies for:
-
-- Gems;
-- recommended Performances;
-- preferred naming;
-- review references;
-- handling uncertain cases.
-
-Architecture documents define the system. Editorial documents define curatorial practice.
-
----
-
-## `site/`: website source
-
-The `site/` directory contains the source files used to produce the GitHub Pages website.
-
-It may include:
-
-- templates;
-- page layouts;
-- styles;
-- JavaScript;
-- static assets;
-- site configuration.
-
-The website must read from canonical or generated data rather than from temporary caches or external APIs during publication.
-
-The precise framework is a later implementation decision.
-
----
-
-## `generated/`: reproducible derived output
-
-The `generated/` directory contains files produced from canonical data or retained sources.
-
-Examples:
-
-```text
-generated/
-├── indexes/
-├── website-data/
-├── search/
-└── lucas-grove/
-```
-
-Possible outputs include:
-
-- Composer indexes;
-- Work indexes;
-- Performance indexes;
-- JSON used by the website;
-- search indexes;
-- converted internal Grove documents;
-- migration previews.
-
-Generated files should be reproducible and should not be edited manually.
-
-Whether they are committed to Git depends on deployment requirements, but their generated status must remain explicit.
-
----
-
-## `cache/`: temporary external data
-
-The `cache/` directory contains temporary or reproducible external metadata used during matching and enrichment.
-
-Suggested layout:
-
-```text
-cache/
-├── tidal/
-├── musicbrainz/
-├── discogs/
-└── wikidata/
-```
-
-Cached data is not canonical.
-
-It may be deleted and rebuilt without changing the collection.
-
-The cache may contain:
-
-- API responses;
-- search candidates;
-- normalised matching records;
-- temporary URL resolution results.
-
-Large or sensitive caches should normally be excluded from Git.
-
----
-
-## `reports/`: review and validation output
-
-The `reports/` directory contains generated information requiring inspection.
-
-Examples:
-
-```text
-reports/
-├── migration/
-├── validation/
-├── unresolved-identities/
-├── duplicate-candidates/
-└── broken-links/
-```
-
-Reports may identify:
-
-- unresolved Composer or Work matches;
-- possible duplicate Performances;
-- invalid references;
-- missing required fields;
-- inactive Tidal links;
-- Gramophone issue references without URLs.
-
-Reports are not canonical data.
-
-A report finding becomes canonical only after a reviewed change to `data/`.
-
----
-
-## `scripts/`: repository operations
-
-The `scripts/` directory contains code for:
-
-- migration;
-- validation;
-- site generation;
-- link checking;
-- source conversion;
-- external matching;
-- report generation.
-
-Scripts should respect the separation between:
-
-- canonical data;
-- retained source material;
-- generated output;
-- temporary cache;
-- reports.
-
-No script may silently overwrite identity-critical canonical data.
-
----
-
-## `tests/`: automated checks
-
-The `tests/` directory contains automated tests for:
-
-- schemas;
-- identifiers;
-- referential integrity;
-- migration semantics;
-- website generation;
-- duplicate detection;
-- source conversion;
-- link parsing.
-
-Tests should particularly protect:
-
-- unique Person identities;
-- unique Work identities;
-- valid Work relationships;
-- valid Performance-to-Work references;
-- preservation of Gem and Performance recommendation semantics.
-
----
-
-## Canonical and non-canonical areas
-
-The repository distinguishes clearly between canonical and non-canonical content.
-
-| Location | Status | Manually edited |
-|---|---|---:|
-| `data/` | canonical collection | yes |
-| `sources/` | retained source material | sometimes |
-| `docs/` | canonical policy and documentation | yes |
-| `site/` | website source | yes |
-| `generated/` | derived output | no |
-| `cache/` | temporary external data | no |
-| `reports/` | derived review output | no |
-| `scripts/` | operational code | yes |
-| `tests/` | automated checks | yes |
-
-Only `data/` defines the entities and recommendations shown on the final website.
-
----
-
-## File granularity
-
-The preferred default is one canonical file per stable entity.
-
-Advantages include:
-
-- stable diffs;
-- simple review;
-- limited merge conflicts;
-- direct validation;
-- easy entity lookup;
-- clear ownership of changes.
-
-The main exception is very small supporting vocabularies, which may be stored in a shared file if they do not represent independent curated entities.
-
-The repository should not create one file per external assertion, track, API response, or review observation.
-
----
-
-## Identifier and filename alignment
-
-Canonical filenames should normally derive from stable repository identifiers.
-
-Example:
-
-```text
-data/works/bruckner-symphony-8-1890.yaml
-```
-
-with:
-
-```yaml
-id: bruckner-symphony-8-1890
-```
-
-Renaming a display title should not automatically require changing the stable identifier.
-
-Detailed slug and identifier rules remain governed by:
-
-- `naming-conventions.md`;
-- `identifier-policy.md`.
-
----
-
-## Identity review boundaries
-
-Routine metadata updates may be automated or reviewed lightly.
-
-The following operations require explicit review:
-
-- creating a new Person where a possible match already exists;
-- merging or splitting Persons;
-- creating a new Work where a possible match already exists;
-- merging or splitting Works;
-- assigning a Performance to a version-specific Work;
-- converting an arrangement, orchestration, revision, or completion into a separate Work;
-- merging Performances;
-- changing the Work referenced by a recommended Performance.
-
-Minor differences in dates, durations, labels, or source spelling do not require a decision record unless they create genuine identity uncertainty.
-
----
-
-## Migration from the current Markdown files
-
-Migration should preserve the present collection rather than reinterpret it unnecessarily.
-
-The migration process should:
-
-1. parse existing Composer and Work structure;
-2. create or match canonical Persons;
-3. create or match canonical Works;
-4. preserve Gem markers as Work recommendations;
-5. create recommended Performances from entries containing Tidal links;
-6. preserve existing Gramophone issue references;
-7. report only genuine ambiguities;
-8. avoid enrichment that is unrelated to identity or website presentation.
-
-Because the current Markdown data is believed to be more than 99% correct, migration should use it as trusted editorial input.
-
-External validation should focus on detecting exceptional identity errors rather than challenging every entry.
-
----
-
-## Adding a new Tidal link
-
-A new Tidal link should eventually support the following repository operation:
-
-```text
-Tidal link
-    ↓
-extract available title and performer metadata
-    ↓
-match existing Person or Composer
-    ↓
-match existing Work
-    ↓
-match or create Performance
-    ↓
-store Tidal link
-    ↓
-review only when Composer or Work identity is uncertain
-```
-
-The detailed matching and workflow design belongs in later workflow documentation.
-
-The repository architecture requires only that the resulting canonical data fits into:
-
-- `data/persons/`;
-- `data/works/`;
-- `data/performances/`.
-
----
-
-## Deferred complexity
-
-The initial repository should not introduce separate persistent entities for:
-
-- Recordings;
-- Releases;
-- Tracks;
-- Albums;
-- Reviews;
-- source assertions;
-- recording sessions;
-- remasterings;
-- platform manifestations.
-
-Such concepts may appear in temporary matching data or external source adapters.
-
-They should become canonical entities only if a demonstrated user or maintenance requirement cannot be met with the current model.
-
----
-
-## Summary
-
-The repository is organised around a small set of stable, curated entities:
-
-```text
-Person
-Work Group
-Work
-Performance
-```
-
-The public website presents Composers, Works, Gems, recommended Performances, Tidal links, and optional Gramophone review links.
-
-The repository deliberately separates:
-
-- canonical collection data;
-- retained source material;
-- generated website output;
-- temporary external metadata;
-- validation and migration reports.
-
-Identity accuracy is mandatory for Persons and Works.
-
-Metadata accumulation is not a project objective.
-
-The architecture should remain simple enough that the collection continues to be recognisable as a curated recommendation list rather than becoming a general-purpose music database.
+Website generation should respect the publication rules in `recommendation-policy.md`: publish the current recommendation for each comparison category, and keep internal workflow state out of the public view unless a later explicit design decision says otherwise.

--- a/docs/architecture/validation-rules.md
+++ b/docs/architecture/validation-rules.md
@@ -1,5 +1,12 @@
 # Validation Rules
 
+> Status: Superseded for entity design by `repository-architecture.md`, `work.md`,
+> `performance.md` and `recommendation-policy.md`.
+>
+> This document records earlier validation ideas for Recording, Release and
+> Recommendation entities. Current validation rules should be derived from the
+> four core canonical entities: Person, Work Group, Work and Performance.
+
 ## Purpose and scope
 
 This document defines repository validation rules for the classical music

--- a/docs/architecture/work-family-analysis.md
+++ b/docs/architecture/work-family-analysis.md
@@ -5,6 +5,12 @@ nav_order: 6
 
 # Work Family Analysis
 
+> Status: Superseded by `repository-architecture.md` and `work.md`.
+>
+> This analysis records an earlier argument for demoting Work Family. The current
+> authoritative design uses Work Group as a canonical grouping entity and requires
+> every Work to belong to exactly one Work Group.
+
 ## Executive conclusion
 
 `Work Family` should not remain a primary standalone domain entity in the conceptual model.

--- a/docs/architecture/work.md
+++ b/docs/architecture/work.md
@@ -2,266 +2,129 @@
 
 ## Purpose
 
-A `Work` represents one distinct musical composition as it is recognised in the
-repository.
+A `Work` represents one distinct artistic composition or version as recognised by the repository.
 
-A Work is the artistic object to which Performances are attached. It is not a
-recording, release, publication or editorial recommendation.
+A Work is the artistic object to which Performances are attached. It is not a recording, release, publication, streaming item or editorial recommendation.
 
-Every Performance refers to exactly one Work.
-
----
-
-## Core principle
-
-A Work is an artistic identity.
-
-Two manifestations belong to the same Work only when they represent the same
-musical work from the curator's perspective.
-
-Identity is determined by musicological judgement rather than by streaming
-metadata.
-
----
-
-## Relationship to Work Group
+## Core rule
 
 Every Work belongs to exactly one Work Group.
 
-The Work Group collects all closely related artistic versions of the same
-underlying composition.
+```text
+Work
+    ↓
+exactly one Work Group
+```
 
-Examples include:
-
-- composer revisions;
-- authorised versions;
-- completions;
-- orchestrations published by the composer.
-
-The Work Group is therefore the umbrella concept.
-
-The Work is the specific artistic version.
-
----
-
-## Revisions
-
-A revision is always a separate Work.
-
-Examples:
-
-- Bruckner Symphony No. 3 (1873)
-- Bruckner Symphony No. 3 (1889)
-
-These belong to the same Work Group but are different Works.
-
-The same applies to substantially different composer-authorised revisions.
-
----
-
-## Arrangements and orchestrations
-
-An arrangement or orchestration becomes a separate Work when it represents a
-distinct artistic work recognised by the composer or musical tradition.
-
-Not every practical transcription deserves a separate Work.
-
-The repository models repertoire, not every playable variant.
-
----
-
-## Individual movements
-
-Normally, individual movements are not separate Works.
-
-The canonical Work is the complete artistic whole.
-
-Exceptions may exist where a movement has become an established independent
-concert work.
-
-Suites published as independent artistic works are separate Works.
-
-The boundary is determined by musical practice rather than by technical
-possibility.
-
----
+A Work Group is the umbrella for closely related Works. The Work is the specific artistic version that can receive Performances.
 
 ## Identity
 
-The following do **not** create a new Work:
+Work identity is determined by musicological and curatorial judgement, not by streaming metadata or release packaging.
+
+The following do not create a new Work:
 
 - different performers;
-- different instruments used in performance;
-- different labels;
 - different recordings;
 - different releases;
-- remasters.
+- remasters;
+- labels or catalogue numbers attached to recordings;
+- changed streaming links.
 
-These belong to Performance.
-
-The following normally **do** create a new Work:
+The following normally create a separate Work:
 
 - composer revisions;
-- distinct composer versions;
+- distinct composer-authorised versions;
+- independently recognised artistic versions;
 - recognised completions;
 - independent suites;
-- independently recognised orchestrations.
+- independently recognised orchestrations or arrangements.
 
----
+Composer revisions are always separate Works within the same Work Group.
 
-## Performance relationship
+## Arrangements, transcriptions and versions
 
-A Work may temporarily have multiple candidate Performances during editorial
-comparison.
+An arrangement, orchestration or transcription becomes a separate Work only when it represents a distinct artistic object recognised by the composer, by musical tradition or by the curator's presentation needs.
 
-After publication, each comparison category has exactly one public
-recommendation, as defined in `recommendation-policy.md`.
+A practical transcription does not automatically deserve a separate Work.
 
-A Work may therefore have multiple published recommendations only when they
-belong to different comparison categories (for example piano versus
-harpsichord).
+The repository models repertoire, not every playable variant.
 
----
+## Movements, arias and excerpts
+
+An individual movement, aria or excerpt is normally not a separate Work merely because it can be performed separately.
+
+An exception may exist when the excerpt has become an established independent concert work or was published as an independent suite.
+
+This is a boundary case. It should be resolved cautiously for the specific repertoire rather than by introducing a large universal classification system.
+
+## Relationship to Performance
+
+Every Performance refers to exactly one Work.
+
+A Work may exist without any recommended Performance. Such Works remain part of the catalogue and must still be eligible for display on the website.
+
+Different performance traditions do not create new Works. When the distinction matters editorially, it is represented by a performance profile on the Performance and by the comparison rules in `recommendation-policy.md`.
 
 ## Performance profiles
 
-Performance profiles are **not** properties of a Work.
+Performance profiles are not properties of a Work.
 
-They are curatorially assigned to Performances.
-
-The workflow may infer a likely profile from external metadata, but the stored
-classification is part of the canonical Performance.
-
-Examples include:
-
-- piano
-- harpsichord
+They are sparse, explicit classifications on Performances. A profile may be proposed from available metadata, such as instrument credits, but the final profile is a canonical curatorial classification.
 
 Most Works require no explicit performance profile.
 
----
-
-## Works without recommendations
-
-A Work may exist without any recommended Performance.
-
-This allows the repository to represent:
-
-- incomplete composer catalogues;
-- future listening plans;
-- repertoire awaiting evaluation.
-
-The website should still display such Works.
-
----
-
 ## Public metadata
 
-A Work contains the information needed to identify and present the composition.
+A Work contains enough information to identify and present the composition.
 
-Typical fields include:
+Typical metadata may include:
 
 - title;
 - composer;
 - catalogue number;
-- year (when useful);
+- opus number;
+- nickname;
 - key;
-- instrumentation;
-- duration (optional);
-- aliases.
+- year, when useful;
+- instrumentation, when useful;
+- aliases;
+- external identifiers.
 
-The public flag:
+The public presentation attribute:
 
 ```yaml
 gem: true
 ```
 
-is solely a presentation feature.
-
-It has no workflow or validation implications.
-
----
-
-## External identifiers
-
-External identifiers may be stored for matching and maintenance.
-
-Examples:
-
-```yaml
-external_ids:
-  musicbrainz_work: ...
-  wikidata: ...
-```
-
-The repository remains authoritative for Work identity.
-
----
+belongs to the Work. It must not affect workflow, validation or prioritisation.
 
 ## Required fields
 
-Initial required fields:
+The initial required fields are:
 
-- id
-- work_group_id
-- composer_id
-- title
+- `id`;
+- `work_group_id`;
+- `composer_id`;
+- `title`.
 
----
-
-## Optional fields
-
-Examples:
-
-- catalogue number
-- opus number
-- nickname
-- key
-- year
-- instrumentation
-- aliases
-- external identifiers
-- gem
-
-The repository should remain intentionally sparse.
-
----
+Exact YAML syntax is deferred to later schema design.
 
 ## Validation
 
-Validation should ensure:
+Validation should ensure that:
 
-1. every Work belongs to one Work Group;
-2. referenced composer exists;
-3. ids are unique;
-4. aliases do not create duplicate Works;
+1. every Work belongs to exactly one Work Group;
+2. every referenced composer exists;
+3. Work identifiers are unique;
+4. aliases do not conceal duplicate Works;
 5. revisions are modelled as separate Works;
-6. Performances reference existing Works.
+6. Performances reference concrete Works, not Work Groups.
 
-Validation should report possible duplicate Works but never merge them
-automatically.
-
----
-
-## File location
-
-Each Work is stored as:
-
-```
-data/works/<work-id>.yaml
-```
-
----
+Validation should report possible duplicate Works for review, not merge them automatically.
 
 ## Summary
 
-A Work is the canonical representation of one artistic composition.
+A Work is one distinct artistic composition or version.
 
-It belongs to exactly one Work Group.
-
-It may have zero or more Performances.
-
-Different recordings, releases and instrumental interpretations do not create
-new Works.
-
-Composer revisions and other artistically distinct versions do.
+It belongs to exactly one Work Group, may have zero or more recommended Performances, and remains independent of recordings, releases, remasters, performers and streaming links.

--- a/docs/architecture/workflow-design-notes.md
+++ b/docs/architecture/workflow-design-notes.md
@@ -1,115 +1,145 @@
 # Workflow Design Notes
 
-## Status
+## Purpose
 
-This document captures the current design decisions regarding the curator workflows for the classical music repository. It is intentionally high-level and serves as input for a later, more detailed `workflow-architecture.md`.
+This document captures high-level curator workflows for migration and day-to-day maintenance.
+
+It is not a schema, automation or implementation specification. Canonical entity boundaries are defined in `repository-architecture.md`, `work.md`, `performance.md` and `recommendation-policy.md`.
 
 ## Guiding principle
 
-The workflows are centred around the activities of the curator rather than the implementation details of the software.
+Workflows are centred around the curator's decisions.
 
-## Primary workflows
+Automation may help identify, validate, report and prepare candidates, but it must not replace editorial judgement or write recommendations automatically.
 
-### 1. Migrate the existing collection
+## Migration workflow
 
-**Phase A – Existing Markdown collection**
+Migration from the existing Markdown collection should preserve durable editorial meaning:
 
-Preserve:
-- Persons (Composers)
-- Works
-- Gem markers
-- recommended Performances
-- Tidal links
-- Gramophone references such as `(10/2021)`
+- Persons in composer roles;
+- Works;
+- Work-level `gem` markers;
+- accepted Performance recommendations;
+- Tidal links;
+- Gramophone references such as `(10/2021)`.
 
-**Phase B – Existing Tidal playlists**
+The migration process should produce reviewable candidates before canonical data is written.
 
-Import the exported Excel playlists (orchestral, chamber and piano music).
+For every migrated entry, determine:
 
-For every playlist entry determine:
+1. the Person in the composer role;
+2. the Work;
+3. the Work Group;
+4. whether the Work already exists;
+5. whether the Performance already exists;
+6. whether the relevant comparison category already has a recommendation.
 
-1. Composer
-2. Work
-3. Whether the Work already exists
-4. Whether the Performance already exists
-5. Whether another recommended Performance already exists
+Multiple candidate Performances of the same Work should be retained in migration review artefacts, not silently promoted into canonical Performance data.
 
-Multiple Performances of the same Work should initially be retained as candidates.
+## Playlist import workflow
 
-### 2. Add a Performance
+Existing exported Tidal playlists may be used as source material.
 
-This is expected to become the primary day-to-day workflow.
+For every playlist entry, determine:
 
-If no recommended Performance exists:
+1. composer identity;
+2. Work identity;
+3. candidate Performance identity;
+4. whether the candidate duplicates an existing Performance;
+5. whether it belongs to an existing comparison category;
+6. whether a comparison issue is needed.
 
-1. Identify Composer
-2. Identify Work
-3. Verify Performance
-4. Add Performance
+Playlist imports must not create canonical Performances until the curator has listened and accepted them as recommendations.
 
-If a recommended Performance already exists:
+## Add a Performance
 
-- Register the candidate Performance
-- Create a GitHub issue requesting editorial comparison
+Adding a Performance is expected to be the primary day-to-day workflow.
+
+If no recommended Performance exists for the comparison category:
+
+1. Identify the Person in the composer role.
+2. Identify or create the Work.
+3. Determine whether a performance profile is relevant.
+4. Verify the Performance.
+5. Listen and accept it.
+6. Add it as the canonical Performance.
+
+If a recommendation already exists in the same comparison category:
+
+1. Register the new item as a candidate outside canonical data.
+2. Create one GitHub issue requesting editorial comparison, when the curator is actively considering it.
+3. Listen.
+4. Record the editorial decision.
 
 Possible outcomes:
 
-- Keep the existing recommendation
-- Replace it
-- Keep both temporarily
-- Conclude both entries are identical
-- Reject the candidate
+- keep the existing recommendation;
+- replace it;
+- conclude both entries are identical;
+- reject the candidate;
+- keep both only if they belong to different comparison categories.
 
-### 3. Extend the catalogue
+## Extend the catalogue
 
 Three scenarios are recognised.
 
-**A. Performance found for an unknown Work**
+### Performance found for an unknown Work
 
-Create the missing Work and attach the Performance.
+Create the missing Work and Work Group as needed, then attach the accepted Performance after listening.
 
-**B. Add a Work without a Performance**
+### Add a Work without a Performance
 
 Works may be added without an immediate recommendation so they appear on the website and can be completed later.
 
-**C. Add the complete catalogue of a Composer**
+### Add the important catalogue of a composer
 
-Populate all important Works of a favourite Composer, leaving recommended Performances for later if necessary.
+Populate important Works of a favourite composer, leaving recommended Performances for later where necessary.
 
-### 4. Add a new Composer
+## Add a Person in the composer role
 
-Typical triggers:
+Typical triggers include:
 
-- Gramophone
-- Radio
-- Newly discovered repertoire
+- Gramophone;
+- radio;
+- newly discovered repertoire;
+- curator interest.
 
 Steps:
 
-1. Check whether the Person already exists
-2. Establish canonical identity
-3. Create the Composer
-4. Add the first Work
-5. Optionally add a recommended Performance
+1. Check whether the Person already exists.
+2. Establish canonical identity.
+3. Create the Person if needed.
+4. Add the first Work.
+5. Optionally add an accepted Performance.
 
-### 5. Maintain Tidal links
+## Search for alternatives
 
-Manual:
+Searching for alternatives is always manually initiated by the curator, per Work.
 
-- Replace obsolete or broken links with updated links to the same Performance.
+A manual request may lead to:
 
-Periodic:
+1. external searching;
+2. a small set of candidate Performances;
+3. one GitHub issue for comparison;
+4. listening;
+5. an editorial decision.
 
-- Investigate automated monthly validation of stored Tidal links.
+`keep_looking: true` may appear on a canonical Performance, but it does not automatically create searches or GitHub Issues. A generated report may list these Performances.
 
-### 6. Add Gramophone references
+## Maintain Tidal links
 
-Low-priority enrichment.
+Replacing an obsolete or broken Tidal link with an updated link to the same interpretation does not create a new Performance.
+
+Periodic link validation may generate reports, but link status should not determine whether the Performance remains recommended.
+
+## Add Gramophone references
+
+Gramophone references are low-priority enrichment.
 
 Store:
 
-- issue (e.g. 2021-10)
-- optional review URL
+- issue, such as `2021-10`;
+- optional review URL.
 
 Review text is not copied into the repository.
 
@@ -117,26 +147,27 @@ Review text is not copied into the repository.
 
 Website publication is not a curator workflow.
 
-Accepted repository changes should automatically trigger:
+Accepted repository changes should trigger:
 
-Repository update
-→ validation
-→ website generation
-→ GitHub Pages publication
+```text
+repository update
+    ↓
+validation
+    ↓
+website generation
+    ↓
+GitHub Pages publication
+```
+
+The website should publish the current recommendation for each comparison category and omit internal workflow state unless a later explicit design decision changes that rule.
 
 ## Summary
 
-Primary editorial workflows:
+Primary editorial workflows are:
 
-1. Migrate the existing collection.
-2. Add or compare Performances.
-3. Extend the catalogue with Works and Composers.
-4. Maintain the collection.
+1. migrate the existing collection;
+2. add or compare Performances;
+3. extend the catalogue with Works and Persons;
+4. maintain links and references.
 
-Supporting processes:
-
-- Tidal link validation
-- Gramophone references
-- Automatic website publication
-
-A future `workflow-architecture.md` will describe the detailed identification and matching pipeline.
+Supporting processes may generate reports and candidates, but canonical recommendations remain the result of manual editorial judgement.


### PR DESCRIPTION
## Summary
- Reframe the active architecture docs around the settled Person, Work Group, Work and Performance model
- Clarify Work and Performance boundaries, recommendation policy, performance profiles, keep_looking, and manual alternative-search workflows
- Mark older overlapping architecture notes and ADRs as superseded where they still describe Recording, Release, Availability or Work Family assumptions

## Scope
- Documentation only
- No schema, migration, workflow automation, data model implementation, or website changes

## Verification
- git diff --cached --check
- Attempted bundle exec jekyll build, but local Bundler 2.5.9 required by Gemfile.lock is not installed