### PR TITLE
Document phase 1 cleanup completion

### DIFF
--- a/docs/roadmap/owner-roadmap.md
+++ b/docs/roadmap/owner-roadmap.md
@@ -1,6 +1,6 @@
 # Owner Roadmap
 
-Last updated: 2026-08-23
+Last updated: 2026-08-24
 
 This is a living document. We will update it regularly as work moves forward.
 
@@ -16,7 +16,7 @@ What is already in place:
 - A project board and issues to track progress.
 
 What is not finished yet:
-- The current collection still needs cleanup and final review.
+- Remaining identity questions need authority-backed review.
 - Some edge cases still need better handling.
 - Final readiness checks are still ahead.
 
@@ -29,6 +29,7 @@ What is not finished yet:
 2. Clean up current data
 - Issue: https://github.com/LuHoo/classical_music/issues/128
 - Focus: fix current mistakes, gaps, and unclear entries.
+- Status: phase-1 cleanup complete; unresolved identity questions are routed to authority review.
 
 3. Make checks part of regular work
 - Issue: https://github.com/LuHoo/classical_music/issues/129

--- a/reports/validation/phase1-completion-issue-128-2026-08-24.md
+++ b/reports/validation/phase1-completion-issue-128-2026-08-24.md
@@ -1,0 +1,78 @@
+# Phase 1 Completion: Issue #128
+
+Issue: <https://github.com/LuHoo/classical_music/issues/128>  
+Date: 2026-08-24
+
+## Completion Decision
+
+Issue #128 is complete for phase 1.
+
+The phase-1 goal was to review the current collection, correct mechanical
+mistakes, and identify missing or unclear pieces before the next phase. That
+work is now represented by the validation reports, duplicate review report, and
+follow-up authority-review issues.
+
+## What Is Complete
+
+- Canonical data validation is in place.
+- The current validation snapshot has no error-level findings.
+- Existing duplicate-looking Work Group and Work clusters have been grouped for
+  review in `reports/validation/duplicate-review-2026-08-23.md`.
+- Mechanical cleanup and current-entry correction work from phase 1 has been
+  separated from identity questions that require curator or authority review.
+- Remaining duplicate warnings are warnings, not validation blockers.
+
+Current phase-1 validation snapshot from
+`reports/validation/phase1-status-2026-08-23.md`:
+
+- Errors: 0
+- Warnings: 115
+- DUP-003 possible duplicate Works: 59
+- DUP-002 possible duplicate Work Groups: 56
+
+Duplicate review inventory:
+
+- DUP-002 Work Group duplicate clusters: 36
+  - mechanically similar / no-manual-review candidates: 21
+  - manual-review candidates: 15
+- DUP-003 Work duplicate clusters: 38
+  - mechanically similar / no-manual-review candidates: 9
+  - manual-review candidates: 29
+
+## Boundary For Remaining Work
+
+The remaining duplicate warnings are not treated as unfinished phase-1 cleanup.
+They are identity-review work.
+
+No additional merge/delete/renumber action should be taken solely from duplicate
+heuristics or catalogue-shaped strings. This is especially important for
+composer/version/catalogue cases where different local records may represent
+distinct works, revisions, arrangements, or incomplete metadata.
+
+The authority-backed follow-up is covered by later work, especially #137 and PR
+#138. Those tasks establish how MusicBrainz and other accepted public authority
+records are used before production identity conclusions are made.
+
+## Environment Note
+
+The validator was not rerun in this local session because this environment does
+not currently provide the repository's Python dev environment:
+
+- repository requirement: Python `>=3.13`
+- available local interpreters checked here: Python 3.9 and Python 3.12
+- missing local packages: `typer`, `pytest`
+
+Use a Python 3.13 environment with dev dependencies installed before running the
+full local validation/test suite:
+
+```bash
+python3.13 -m pip install -e '.[dev]'
+python3.13 scripts/validate_data.py --json
+python3.13 -m pytest
+```
+
+## Closure
+
+Phase 1 cleanup is ready to close. The collection is ready for the next phase
+with remaining identity questions explicitly routed to authority-backed review
+rather than hidden inside phase-1 cleanup.


### PR DESCRIPTION
## Summary
- adds a phase-1 completion note for #128
- updates the owner roadmap to mark current-data cleanup as complete
- explicitly routes remaining duplicate identity questions to authority-backed review instead of phase-1 cleanup

Closes #128

## Validation
- not rerun locally: this environment lacks the repository Python >=3.13 dev environment and missing packages such as typer/pytest
- completion note records the existing phase-1 validation snapshot and the environment limitation