### PR TITLE
Make validation checks regular and readable

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   validate:
@@ -21,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ruamel.yaml pydantic rich typer
+          python -m pip install -e '.[dev]'
 
       - name: Run validator (human-readable)
         run: python scripts/validate_data.py
@@ -29,6 +30,13 @@ jobs:
       - name: Run validator (JSON artifact)
         if: always()
         run: python scripts/validate_data.py --json > validation-report.json || true
+
+      - name: Add validation summary
+        if: always()
+        run: python scripts/summarize_validation_report.py validation-report.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run tests
+        run: python -m pytest
 
       - name: Upload validation report
         if: always()

--- a/docs/contributor/validation.md
+++ b/docs/contributor/validation.md
@@ -19,13 +19,13 @@ The validator enforces:
 Python 3.13+ is required.
 
 ```bash
-python -m pip install ruamel.yaml pydantic rich typer
+python -m pip install -e .
 ```
 
 Optional test dependencies:
 
 ```bash
-python -m pip install pytest pytest-cov
+python -m pip install -e '.[dev]'
 ```
 
 ## Run Validator
@@ -81,9 +81,29 @@ Validation runs in GitHub Actions via:
 
 The workflow:
 
-- runs the human-readable validator (fails on errors),
+- runs on every pull request and every push to `main`,
+- can be run manually from the Actions tab,
+- installs the project with dev dependencies,
+- runs the human-readable validator, failing on validation errors,
 - emits a JSON report,
-- uploads it as the `validation-report` artifact.
+- adds a concise validation summary to the GitHub Actions job summary,
+- runs the test suite,
+- uploads the full JSON report as the `validation-report` artifact.
+
+The job summary is the quickest owner-facing view. It shows error, warning and
+info counts, the most common rule groups, and the first findings that need
+attention. Use the JSON artifact when a full machine-readable report is needed.
+
+## Run The Regular Checks Locally
+
+Use the same checks before opening or updating a pull request:
+
+```bash
+python scripts/validate_data.py
+python scripts/validate_data.py --json > validation-report.json
+python scripts/summarize_validation_report.py validation-report.json
+python -m pytest
+```
 
 ## Validation Flow
 

--- a/docs/roadmap/owner-roadmap.md
+++ b/docs/roadmap/owner-roadmap.md
@@ -34,6 +34,7 @@ What is not finished yet:
 3. Make checks part of regular work
 - Issue: https://github.com/LuHoo/classical_music/issues/129
 - Focus: ensure every update is checked automatically.
+- Status: automated PR/main checks include validation, tests, artifacts, and an owner-readable job summary.
 
 4. Set up review flow for new candidates
 - Issue: https://github.com/LuHoo/classical_music/issues/130

--- a/scripts/summarize_validation_report.py
+++ b/scripts/summarize_validation_report.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def top_rule_counts(findings: list[dict[str, Any]], limit: int) -> list[tuple[str, int]]:
+    counts = Counter(str(finding.get("rule_id", "unknown")) for finding in findings)
+    return counts.most_common(limit)
+
+
+def render_summary(report: dict[str, Any], limit: int) -> str:
+    findings = list(report.get("findings", []))
+    errors = int(report.get("error_count", 0))
+    warnings = int(report.get("warning_count", 0))
+    info = int(report.get("info_count", 0))
+
+    lines = [
+        "## Canonical Data Validation",
+        "",
+        f"- Errors: {errors}",
+        f"- Warnings: {warnings}",
+        f"- Info: {info}",
+        "",
+    ]
+
+    if errors:
+        lines.extend([
+            "### Attention Needed",
+            "",
+            "Validation errors block regular work and should be fixed before merging.",
+            "",
+        ])
+    elif warnings:
+        lines.extend([
+            "### Attention Needed",
+            "",
+            "No blocking errors. Warnings remain review items.",
+            "",
+        ])
+    else:
+        lines.extend([
+            "### Attention Needed",
+            "",
+            "No validation findings.",
+            "",
+        ])
+
+    if findings:
+        lines.extend([
+            "### Top Rule Groups",
+            "",
+            "| Rule | Count |",
+            "| --- | ---: |",
+        ])
+        for rule_id, count in top_rule_counts(findings, limit):
+            lines.append(f"| `{rule_id}` | {count} |")
+        lines.append("")
+
+        lines.extend([
+            "### First Findings",
+            "",
+            "| Severity | Rule | File | Message |",
+            "| --- | --- | --- | --- |",
+        ])
+        for finding in findings[:limit]:
+            severity = str(finding.get("severity", ""))
+            rule_id = str(finding.get("rule_id", ""))
+            file_path = str(finding.get("file", ""))
+            message = str(finding.get("message", "")).replace("|", "\\|")
+            lines.append(f"| {severity} | `{rule_id}` | `{file_path}` | {message} |")
+        lines.append("")
+
+    lines.append("Full machine-readable details are available in the `validation-report` artifact.")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render a GitHub summary for validation-report.json")
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--limit", type=int, default=10)
+    args = parser.parse_args()
+
+    print(render_summary(load_report(args.report), args.limit), end="")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- installs project dev dependencies in the validation workflow
- runs validation on PRs, pushes to main, and manual dispatch
- adds a GitHub Actions job summary for validation counts, top rule groups, and first findings
- runs pytest as part of the regular validation workflow
- documents the regular local and CI check flow for contributors/owner review

Closes #129

## Validation
- tested `scripts/summarize_validation_report.py` with a sample validation JSON
- ran `git diff --check`
- full validator/pytest not run locally because this environment lacks the repo's Python >=3.13 dev environment
